### PR TITLE
use https://rubygems.org

### DIFF
--- a/source/v0.9/gemfile.haml
+++ b/source/v0.9/gemfile.haml
@@ -8,7 +8,7 @@
     :code
       # lang: ruby
       source :rubygems
-      source 'http://rubygems.org'
+      source 'https://rubygems.org'
       source :rubyforge
       source 'http://gems.rubyforge.org'
       source :gemcutter

--- a/source/v0.9/index.haml
+++ b/source/v0.9/index.haml
@@ -23,7 +23,7 @@
       Specify your dependencies in a Gemfile in your project's root
     :code
       # lang: ruby
-      source 'http://rubygems.org'
+      source 'https://rubygems.org'
       gem 'nokogiri'
       gem 'rack', '~>1.1'
       gem 'rspec', :require => 'spec'

--- a/source/v1.0/gemfile.haml
+++ b/source/v1.0/gemfile.haml
@@ -17,7 +17,7 @@
     :code
       # lang: ruby
       source :rubygems
-      source "http://rubygems.org"
+      source "https://rubygems.org"
       source :rubyforge
       source "http://gems.rubyforge.org"
       source :gemcutter

--- a/source/v1.0/index.haml
+++ b/source/v1.0/index.haml
@@ -26,7 +26,7 @@
       Specify your dependencies in a Gemfile in your project's root
     :code
       # lang: ruby
-      source "http://rubygems.org"
+      source "https://rubygems.org"
       gem "nokogiri"
       gem "rack", "~>1.1"
       gem "rspec", :require => "spec"

--- a/source/v1.0/rationale.haml
+++ b/source/v1.0/rationale.haml
@@ -20,7 +20,7 @@
 
   :code
     # lang: ruby
-    source "http://rubygems.org"
+    source "https://rubygems.org"
 
     gem "rails", "3.0.0.rc"
     gem "rack-cache"
@@ -28,7 +28,7 @@
 
   %p
     This <code>Gemfile</code> says a few things. First, it says that bundler should look for gems
-    declared in the <code>Gemfile</code> at <code>http://rubygems.org</code>. You can declare
+    declared in the <code>Gemfile</code> at <code>https://rubygems.org</code>. You can declare
     multiple Rubygems sources, and bundler will look for gems in the order you declared the
     sources.
 
@@ -140,7 +140,7 @@
 
   :code
     # lang: ruby
-    source "http://rubygems.org"
+    source "https://rubygems.org"
 
     gem "rails", "3.0.0.rc"
     gem "rack-cache", :require => "rack/cache"
@@ -167,7 +167,7 @@
 
   :code
     # lang: ruby
-    source "http://rubygems.org"
+    source "https://rubygems.org"
 
     gem "rails", "3.2.2"
     gem "rack-cache", :require => "rack/cache"
@@ -613,7 +613,7 @@
 
       :code
         # lang: ruby
-        source "http://rubygems.org"
+        source "https://rubygems.org"
 
         gem "sinatra", "~> 0.9.0"
         gem "rack-cache"
@@ -632,7 +632,7 @@
 
       :code
         # lang: ruby
-        source "http://rubygems.org"
+        source "https://rubygems.org"
 
         gem "sinatra", "~> 1.0.0"
         gem "rack-cache"

--- a/source/v1.1/gemfile.haml
+++ b/source/v1.1/gemfile.haml
@@ -17,7 +17,7 @@
     :code
       # lang: ruby
       source :rubygems
-      source 'http://rubygems.org'
+      source 'https://rubygems.org'
       source :rubyforge
       source 'http://gems.rubyforge.org'
       source :gemcutter

--- a/source/v1.1/index.haml
+++ b/source/v1.1/index.haml
@@ -26,7 +26,7 @@
       Specify your dependencies in a Gemfile in your project's root
     :code
       # lang: ruby
-      source 'http://rubygems.org'
+      source 'https://rubygems.org'
       gem 'nokogiri'
       gem 'rack', '~>1.1'
       gem 'rspec', :require => 'spec'

--- a/source/v1.1/rationale.haml
+++ b/source/v1.1/rationale.haml
@@ -20,7 +20,7 @@
 
   :code
     # lang: ruby
-    source 'http://rubygems.org'
+    source 'https://rubygems.org'
 
     gem 'rails', '3.0.0.rc'
     gem 'rack-cache'
@@ -28,7 +28,7 @@
 
   %p
     This <code>Gemfile</code> says a few things. First, it says that bundler should look for gems
-    declared in the <code>Gemfile</code> at <code>http://rubygems.org</code>. You can declare
+    declared in the <code>Gemfile</code> at <code>https://rubygems.org</code>. You can declare
     multiple Rubygems sources, and bundler will look for gems in the order you declared the
     sources.
 
@@ -140,7 +140,7 @@
 
   :code
     # lang: ruby
-    source 'http://rubygems.org'
+    source 'https://rubygems.org'
 
     gem 'rails', '3.0.0.rc'
     gem 'rack-cache', :require => 'rack/cache'
@@ -167,7 +167,7 @@
 
   :code
     # lang: ruby
-    source 'http://rubygems.org'
+    source 'https://rubygems.org'
 
     gem 'rails', '3.2.2'
     gem 'rack-cache', :require => 'rack/cache'
@@ -613,7 +613,7 @@
 
       :code
         # lang: ruby
-        source 'http://rubygems.org'
+        source 'https://rubygems.org'
 
         gem 'sinatra', '~> 0.9.0'
         gem 'rack-cache'
@@ -632,7 +632,7 @@
 
       :code
         # lang: ruby
-        source 'http://rubygems.org'
+        source 'https://rubygems.org'
 
         gem 'sinatra', '~> 1.0.0'
         gem 'rack-cache'

--- a/source/v1.2/bundle_update.haml
+++ b/source/v1.2/bundle_update.haml
@@ -63,7 +63,7 @@
 
         :code
           # lang: ruby
-          source 'http://rubygems.org'
+          source 'https://rubygems.org'
           gem 'rails', '3.0.0.rc'
           gem 'nokogiri'
       %p
@@ -71,7 +71,7 @@
         resolve all of the dependencies, all the way down, and install what you
         need:
         :code
-          Fetching source index for http://rubygems.org/
+          Fetching source index for https://rubygems.org/
           Installing rake (0.8.7)
           Installing abstract (1.0.0)
           Installing activesupport (3.0.0.rc)
@@ -160,7 +160,7 @@
 
         :code
           # lang: ruby
-          source 'http://rubygems.org'
+          source 'https://rubygems.org'
 
           gem 'thin'
           gem 'rack-perftools-profiler'
@@ -171,7 +171,7 @@
         If you run bundle install, you get:
 
         :code
-          Fetching source index for http://rubygems.org/
+          Fetching source index for https://rubygems.org/
           Installing daemons (1.1.0)
           Installing eventmachine (0.12.10) with native extensions
           Installing open4 (1.0.1)

--- a/source/v1.2/gemfile.haml
+++ b/source/v1.2/gemfile.haml
@@ -17,7 +17,7 @@
     :code
       # lang: ruby
       source :rubygems
-      source 'http://rubygems.org'
+      source 'https://rubygems.org'
       source :rubyforge
       source 'http://gems.rubyforge.org'
       source :gemcutter

--- a/source/v1.2/rationale.haml
+++ b/source/v1.2/rationale.haml
@@ -20,7 +20,7 @@
 
   :code
     # lang: ruby
-    source 'http://rubygems.org'
+    source 'https://rubygems.org'
 
     gem 'rails', '3.0.0.rc'
     gem 'rack-cache'
@@ -28,7 +28,7 @@
 
   %p
     This <code>Gemfile</code> says a few things. First, it says that bundler should look for gems
-    declared in the <code>Gemfile</code> at <code>http://rubygems.org</code>. You can declare
+    declared in the <code>Gemfile</code> at <code>https://rubygems.org</code>. You can declare
     multiple Rubygems sources, and bundler will look for gems in the order you declared the
     sources.
 
@@ -140,7 +140,7 @@
 
   :code
     # lang: ruby
-    source 'http://rubygems.org'
+    source 'https://rubygems.org'
 
     gem 'rails', '3.0.0.rc'
     gem 'rack-cache', :require => 'rack/cache'
@@ -167,7 +167,7 @@
 
   :code
     # lang: ruby
-    source 'http://rubygems.org'
+    source 'https://rubygems.org'
 
     gem 'rails', '3.2.2'
     gem 'rack-cache', :require => 'rack/cache'
@@ -613,7 +613,7 @@
 
       :code
         # lang: ruby
-        source 'http://rubygems.org'
+        source 'https://rubygems.org'
 
         gem 'sinatra', '~> 0.9.0'
         gem 'rack-cache'
@@ -632,7 +632,7 @@
 
       :code
         # lang: ruby
-        source 'http://rubygems.org'
+        source 'https://rubygems.org'
 
         gem 'sinatra', '~> 1.0.0'
         gem 'rack-cache'

--- a/source/v1.3/bundle_update.haml
+++ b/source/v1.3/bundle_update.haml
@@ -63,7 +63,7 @@
 
         :code
           # lang: ruby
-          source 'http://rubygems.org'
+          source 'https://rubygems.org'
           gem 'rails', '3.0.0.rc'
           gem 'nokogiri'
       %p
@@ -71,7 +71,7 @@
         resolve all of the dependencies, all the way down, and install what you
         need:
         :code
-          Fetching source index for http://rubygems.org/
+          Fetching source index for https://rubygems.org/
           Installing rake (0.8.7)
           Installing abstract (1.0.0)
           Installing activesupport (3.0.0.rc)
@@ -160,7 +160,7 @@
 
         :code
           # lang: ruby
-          source 'http://rubygems.org'
+          source 'https://rubygems.org'
 
           gem 'thin'
           gem 'rack-perftools-profiler'
@@ -171,7 +171,7 @@
         If you run bundle install, you get:
 
         :code
-          Fetching source index for http://rubygems.org/
+          Fetching source index for https://rubygems.org/
           Installing daemons (1.1.0)
           Installing eventmachine (0.12.10) with native extensions
           Installing open4 (1.0.1)

--- a/source/v1.3/bundler_setup.haml
+++ b/source/v1.3/bundler_setup.haml
@@ -83,7 +83,7 @@
 
   :code
       # lang: ruby
-    source 'http://rubygems.org'
+    source 'https://rubygems.org'
 
     gem 'rails', '3.0.0.rc'
     gem 'rack-cache', :require => 'rack/cache'

--- a/source/v1.3/bundler_workflow.haml
+++ b/source/v1.3/bundler_workflow.haml
@@ -75,7 +75,7 @@
 
     .notes
       This <code>Gemfile</code> says a few things. First, it says that bundler should 
-      look for gems declared in the <code>Gemfile</code> at <code>http://rubygems.org</code>. 
+      look for gems declared in the <code>Gemfile</code> at <code>https://rubygems.org</code>. 
       You can declare multiple Rubygems sources, and bundler will look for gems in the order 
       you declared the sources.
     = link_to 'Learn More: Gemfiles', '/v1.3/gemfile.html'

--- a/source/v1.3/groups.haml
+++ b/source/v1.3/groups.haml
@@ -79,7 +79,7 @@
 
   :code
     # lang: ruby
-    source 'http://rubygems.org'
+    source 'https://rubygems.org'
 
     gem 'rails', '3.2.2'
     gem 'rack-cache', :require => 'rack/cache'

--- a/source/v1.3/rationale.haml
+++ b/source/v1.3/rationale.haml
@@ -20,7 +20,7 @@
 
   %p
     This <code>Gemfile</code> says a few things. First, it says that bundler should look for gems
-    declared in the <code>Gemfile</code> at <code>http://rubygems.org</code>. You can declare
+    declared in the <code>Gemfile</code> at <code>https://rubygems.org</code>. You can declare
     multiple Rubygems sources, and bundler will look for gems in the order you declared the
     sources.
 
@@ -132,7 +132,7 @@
 
   :code
     # lang: ruby
-    source 'http://rubygems.org'
+    source 'https://rubygems.org'
 
     gem 'rails', '3.0.0.rc'
     gem 'rack-cache', :require => 'rack/cache'
@@ -335,7 +335,7 @@
 
       :code
         # lang: ruby
-        source 'http://rubygems.org'
+        source 'https://rubygems.org'
 
         gem 'sinatra', '~> 0.9.0'
         gem 'rack-cache'
@@ -354,7 +354,7 @@
 
       :code
         # lang: ruby
-        source 'http://rubygems.org'
+        source 'https://rubygems.org'
 
         gem 'sinatra', '~> 1.0.0'
         gem 'rack-cache'

--- a/source/v1.5/bundle_update.haml
+++ b/source/v1.5/bundle_update.haml
@@ -63,7 +63,7 @@
 
         :code
           # lang: ruby
-          source 'http://rubygems.org'
+          source 'https://rubygems.org'
           gem 'rails', '3.0.0.rc'
           gem 'nokogiri'
       %p
@@ -71,7 +71,7 @@
         resolve all of the dependencies, all the way down, and install what you
         need:
         :code
-          Fetching source index for http://rubygems.org/
+          Fetching source index for https://rubygems.org/
           Installing rake (0.8.7)
           Installing abstract (1.0.0)
           Installing activesupport (3.0.0.rc)
@@ -160,7 +160,7 @@
 
         :code
           # lang: ruby
-          source 'http://rubygems.org'
+          source 'https://rubygems.org'
 
           gem 'thin'
           gem 'rack-perftools-profiler'
@@ -171,7 +171,7 @@
         If you run bundle install, you get:
 
         :code
-          Fetching source index for http://rubygems.org/
+          Fetching source index for https://rubygems.org/
           Installing daemons (1.1.0)
           Installing eventmachine (0.12.10) with native extensions
           Installing open4 (1.0.1)

--- a/source/v1.5/bundler_setup.haml
+++ b/source/v1.5/bundler_setup.haml
@@ -88,7 +88,7 @@
 
     :code
       # lang: ruby
-      source 'http://rubygems.org'
+      source 'https://rubygems.org'
 
       gem 'rails', '3.0.0.rc'
       gem 'rack-cache', :require => 'rack/cache'

--- a/source/v1.5/bundler_workflow.haml
+++ b/source/v1.5/bundler_workflow.haml
@@ -75,7 +75,7 @@
 
     .notes
       This <code>Gemfile</code> says a few things. First, it says that bundler should 
-      look for gems declared in the <code>Gemfile</code> at <code>http://rubygems.org</code>. 
+      look for gems declared in the <code>Gemfile</code> at <code>https://rubygems.org</code>. 
       You can declare multiple Rubygems sources, and bundler will look for gems in the order 
       you declared the sources.
     = link_to 'Learn More: Gemfiles', '/v1.5/gemfile.html'

--- a/source/v1.5/groups.haml
+++ b/source/v1.5/groups.haml
@@ -78,7 +78,7 @@
 
     :code
       # lang: ruby
-      source 'http://rubygems.org'
+      source 'https://rubygems.org'
 
       gem 'rails', '3.2.2'
       gem 'rack-cache', :require => 'rack/cache'

--- a/source/v1.5/rationale.haml
+++ b/source/v1.5/rationale.haml
@@ -20,7 +20,7 @@
 
   %p
     This <code>Gemfile</code> says a few things. First, it says that bundler should look for gems
-    declared in the <code>Gemfile</code> at <code>http://rubygems.org</code>. You can declare
+    declared in the <code>Gemfile</code> at <code>https://rubygems.org</code>. You can declare
     multiple Rubygems sources, and bundler will look for gems in the order you declared the
     sources.
 
@@ -133,7 +133,7 @@
 
   :code
     # lang: ruby
-    source 'http://rubygems.org'
+    source 'https://rubygems.org'
 
     gem 'rails', '3.0.0.rc'
     gem 'rack-cache', :require => 'rack/cache'
@@ -336,7 +336,7 @@
 
       :code
         # lang: ruby
-        source 'http://rubygems.org'
+        source 'https://rubygems.org'
 
         gem 'sinatra', '~> 0.9.0'
         gem 'rack-cache'
@@ -355,7 +355,7 @@
 
       :code
         # lang: ruby
-        source 'http://rubygems.org'
+        source 'https://rubygems.org'
 
         gem 'sinatra', '~> 1.0.0'
         gem 'rack-cache'

--- a/source/v1.5/whats_new.haml
+++ b/source/v1.5/whats_new.haml
@@ -21,7 +21,7 @@
 .contents
   .bullet
     .description
-      Bundler now supports the ability to use a gem mirror in a Gemfile locally by using <code>bundle config</code>. <code> bundle config mirror.http://rubygems.org http://rubygems-mirror.org/</code>
+      Bundler now supports the ability to use a gem mirror in a Gemfile locally by using <code>bundle config</code>. <code> bundle config mirror.https://rubygems.org https://rubygems-mirror.org/</code>
     = link_to 'Learn More: Source Mirrors', './bundle_config.html#gem-source-mirrors'
 
 %h2#ruby-patchlevel
@@ -61,4 +61,3 @@
         %li a <code>bundler</code> command in case you typo <code>bundle</code>
         %li uses RUBYLIB for better compatibility with Windows
         = link_to 'Full 1.5 changelog', 'https://github.com/bundler/bundler/blob/1-5-stable/CHANGELOG.md'
-

--- a/source/v1.6/bundle_update.haml
+++ b/source/v1.6/bundle_update.haml
@@ -72,7 +72,7 @@
 
         :code
           # lang: ruby
-          source 'http://rubygems.org'
+          source 'https://rubygems.org'
           gem 'rails', '3.0.0.rc'
           gem 'nokogiri'
       %p
@@ -80,7 +80,7 @@
         resolve all of the dependencies, all the way down, and install what you
         need:
         :code
-          Fetching source index for http://rubygems.org/
+          Fetching source index for https://rubygems.org/
           Installing rake (0.8.7)
           Installing abstract (1.0.0)
           Installing activesupport (3.0.0.rc)
@@ -169,7 +169,7 @@
 
         :code
           # lang: ruby
-          source 'http://rubygems.org'
+          source 'https://rubygems.org'
 
           gem 'thin'
           gem 'rack-perftools-profiler'
@@ -180,7 +180,7 @@
         If you run bundle install, you get:
 
         :code
-          Fetching source index for http://rubygems.org/
+          Fetching source index for https://rubygems.org/
           Installing daemons (1.1.0)
           Installing eventmachine (0.12.10) with native extensions
           Installing open4 (1.0.1)

--- a/source/v1.6/bundler_setup.haml
+++ b/source/v1.6/bundler_setup.haml
@@ -88,7 +88,7 @@
 
     :code
       # lang: ruby
-      source 'http://rubygems.org'
+      source 'https://rubygems.org'
 
       gem 'rails', '3.0.0.rc'
       gem 'rack-cache', :require => 'rack/cache'

--- a/source/v1.6/bundler_workflow.haml
+++ b/source/v1.6/bundler_workflow.haml
@@ -75,7 +75,7 @@
 
     .notes
       This <code>Gemfile</code> says a few things. First, it says that bundler should 
-      look for gems declared in the <code>Gemfile</code> at <code>http://rubygems.org</code>. 
+      look for gems declared in the <code>Gemfile</code> at <code>https://rubygems.org</code>. 
       You can declare multiple Rubygems sources, and bundler will look for gems in the order 
       you declared the sources.
     = link_to 'Learn More: Gemfiles', '/v1.6/gemfile.html'

--- a/source/v1.6/groups.haml
+++ b/source/v1.6/groups.haml
@@ -78,7 +78,7 @@
 
     :code
       # lang: ruby
-      source 'http://rubygems.org'
+      source 'https://rubygems.org'
 
       gem 'rails', '3.2.2'
       gem 'rack-cache', :require => 'rack/cache'

--- a/source/v1.7/bundle_update.haml
+++ b/source/v1.7/bundle_update.haml
@@ -72,7 +72,7 @@
 
         :code
           # lang: ruby
-          source 'http://rubygems.org'
+          source 'https://rubygems.org'
           gem 'rails', '3.0.0.rc'
           gem 'nokogiri'
       %p
@@ -80,7 +80,7 @@
         resolve all of the dependencies, all the way down, and install what you
         need:
         :code
-          Fetching source index for http://rubygems.org/
+          Fetching source index for https://rubygems.org/
           Installing rake (0.8.7)
           Installing abstract (1.0.0)
           Installing activesupport (3.0.0.rc)
@@ -169,7 +169,7 @@
 
         :code
           # lang: ruby
-          source 'http://rubygems.org'
+          source 'https://rubygems.org'
 
           gem 'thin'
           gem 'rack-perftools-profiler'
@@ -180,7 +180,7 @@
         If you run bundle install, you get:
 
         :code
-          Fetching source index for http://rubygems.org/
+          Fetching source index for https://rubygems.org/
           Installing daemons (1.1.0)
           Installing eventmachine (0.12.10) with native extensions
           Installing open4 (1.0.1)

--- a/source/v1.7/bundler_setup.haml
+++ b/source/v1.7/bundler_setup.haml
@@ -88,7 +88,7 @@
 
     :code
       # lang: ruby
-      source 'http://rubygems.org'
+      source 'https://rubygems.org'
 
       gem 'rails', '3.0.0.rc'
       gem 'rack-cache', :require => 'rack/cache'

--- a/source/v1.7/bundler_workflow.haml
+++ b/source/v1.7/bundler_workflow.haml
@@ -75,7 +75,7 @@
 
     .notes
       This <code>Gemfile</code> says a few things. First, it says that bundler should
-      look for gems declared in the <code>Gemfile</code> at <code>http://rubygems.org</code> by default.
+      look for gems declared in the <code>Gemfile</code> at <code>https://rubygems.org</code> by default.
     = link_to 'Learn More: Gemfiles', './gemfile.html'
 
   .bullet

--- a/source/v1.7/groups.haml
+++ b/source/v1.7/groups.haml
@@ -78,7 +78,7 @@
 
     :code
       # lang: ruby
-      source 'http://rubygems.org'
+      source 'https://rubygems.org'
 
       gem 'rails', '3.2.2'
       gem 'rack-cache', :require => 'rack/cache'

--- a/source/v1.8/bundle_update.haml
+++ b/source/v1.8/bundle_update.haml
@@ -72,7 +72,7 @@
 
         :code
           # lang: ruby
-          source 'http://rubygems.org'
+          source 'https://rubygems.org'
           gem 'rails', '3.0.0.rc'
           gem 'nokogiri'
       %p
@@ -80,7 +80,7 @@
         resolve all of the dependencies, all the way down, and install what you
         need:
         :code
-          Fetching source index for http://rubygems.org/
+          Fetching source index for https://rubygems.org/
           Installing rake (0.8.7)
           Installing abstract (1.0.0)
           Installing activesupport (3.0.0.rc)
@@ -169,7 +169,7 @@
 
         :code
           # lang: ruby
-          source 'http://rubygems.org'
+          source 'https://rubygems.org'
 
           gem 'thin'
           gem 'rack-perftools-profiler'
@@ -180,7 +180,7 @@
         If you run bundle install, you get:
 
         :code
-          Fetching source index for http://rubygems.org/
+          Fetching source index for https://rubygems.org/
           Installing daemons (1.1.0)
           Installing eventmachine (0.12.10) with native extensions
           Installing open4 (1.0.1)

--- a/source/v1.8/bundler_setup.haml
+++ b/source/v1.8/bundler_setup.haml
@@ -88,7 +88,7 @@
 
     :code
       # lang: ruby
-      source 'http://rubygems.org'
+      source 'https://rubygems.org'
 
       gem 'rails', '3.0.0.rc'
       gem 'rack-cache', :require => 'rack/cache'

--- a/source/v1.8/bundler_workflow.haml
+++ b/source/v1.8/bundler_workflow.haml
@@ -75,7 +75,7 @@
 
     .notes
       This <code>Gemfile</code> says a few things. First, it says that bundler should
-      look for gems declared in the <code>Gemfile</code> at <code>http://rubygems.org</code> by default.
+      look for gems declared in the <code>Gemfile</code> at <code>https://rubygems.org</code> by default.
     = link_to 'Learn More: Gemfiles', './gemfile.html'
 
   .bullet

--- a/source/v1.8/groups.haml
+++ b/source/v1.8/groups.haml
@@ -78,7 +78,7 @@
 
     :code
       # lang: ruby
-      source 'http://rubygems.org'
+      source 'https://rubygems.org'
 
       gem 'rails', '3.2.2'
       gem 'rack-cache', :require => 'rack/cache'


### PR DESCRIPTION
Since using HTTPS is much more secure than HTTP, it would be better to use HTTPS in the documentation.

I believe old versions of bundle also work with https source.