### PR TITLE
Fix code indentation in blog posts

### DIFF
--- a/source/layouts/blog_layout.haml
+++ b/source/layouts/blog_layout.haml
@@ -19,5 +19,6 @@
             %time
               = current_article.date.strftime('%b %e %Y')
           %hr
-          = yield
+          = find_and_preserve do
+            = yield
     = partial 'partials/footer', locals: { v: v }


### PR DESCRIPTION
Turns this:
![screenshot 2015-03-21 16 00 48](https://cloud.githubusercontent.com/assets/1585126/6767011/83a7417c-cfe3-11e4-870a-e98a07848a4a.png)

Into this:
![screenshot 2015-03-21 16 02 44](https://cloud.githubusercontent.com/assets/1585126/6767026/bc8aea84-cfe3-11e4-975c-b3d483f8afc1.png)

This solution was proposed in this issue: https://github.com/middleman/middleman-syntax/issues/16