### PR TITLE
Update README.md with optional -h (host) and -p (port) flags when exe…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # bundler.io
-bundler.io is intended to serve as a convenient source for documentation on the [bundler](https://github.com/bundler/bundler) gem. 
+bundler.io is intended to serve as a convenient source for documentation on the [bundler](https://github.com/bundler/bundler) gem.
 
 The site bundler.io is a static site generated using [Middleman](http://middlemanapp.com/).
 
@@ -12,6 +12,10 @@ Run a local development web server:
     bundle exec middleman server
 
 This will start a local web server running at: *http://localhost:4567*. It will serve the site as it exists in **/source**.
+
+To specify the host and/or port, add the -h, -p flag(s):
+
+    bundle exec middleman -h 0.0.0.0 -p 8080
 
 Note: the development server will automatically reload pages when they or there associated stylesheets are modified. This feature is enabled in **config.rb**.
 


### PR DESCRIPTION
…cuting middleman

Useful when it is necessary to specify a host and/or port other than the default. eg. In the case of using c9.io, the only available port is 8080.