### PR TITLE
Fix content extending into the side bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # bundler.io
-bundler.io is intended to serve as a convenient source for documentation on the [bundler](https://github.com/bundler/bundler) gem. 
+bundler.io is intended to serve as a convenient source for documentation on the [bundler](https://github.com/bundler/bundler) gem.
 
 The site bundler.io is a static site generated using [Middleman](http://middlemanapp.com/).
 
@@ -12,6 +12,10 @@ Run a local development web server:
     bundle exec middleman server
 
 This will start a local web server running at: *http://localhost:4567*. It will serve the site as it exists in **/source**.
+
+To specify the host and/or port, add the -h, -p flag(s):
+
+    bundle exec middleman -h 0.0.0.0 -p 8080
 
 Note: the development server will automatically reload pages when they or there associated stylesheets are modified. This feature is enabled in **config.rb**.
 

--- a/source/v1.9/bundle_update.haml
+++ b/source/v1.9/bundle_update.haml
@@ -6,7 +6,8 @@
       Update the current environment
 
     :code
-      $ bundle update [GEM] [--full-index] [--group=GROUP] [--jobs=NUMBER] [--local] [--quiet] [--source=SOURCE]
+      $ bundle update [GEM] [--full-index] [--group=GROUP] [--jobs=NUMBER] [--local] 
+                            [--quiet] [--source=SOURCE]
     .notes
       %p
         Options:
@@ -27,13 +28,15 @@
         associated with it)
 
     .description
-      Update the gems specified (all gems, if none are specified), ignoring
-      the previously installed gems specified in the <code>Gemfile.lock</code>.
-      In general, you should use <code>bundle install</code> to install the same
-      exact gems and versions across machines.
-
-      You would use <code>bundle update</code> to explicitly update the version
-      of a gem.
+      %p
+        Update the gems specified (all gems, if none are specified), ignoring
+        the previously installed gems specified in the <code>Gemfile.lock</code>.
+        In general, you should use <code>bundle install</code> to install the
+        same exact gems and versions across machines.
+      
+      %p
+        You would use <code>bundle update</code> to explicitly update the 
+        version of a gem.
 
   .bullet
     .description


### PR DESCRIPTION
On the bundle update command page, it can be observed that some of the content from the command block and some text below it leaks into the side bar causing the text to clash. This pull request aligns the text properly.