### PR TITLE
Explain that install --deployment is also suitable for CI

### DIFF
--- a/source/v1.10/bundle_install.haml
+++ b/source/v1.10/bundle_install.haml
@@ -19,7 +19,7 @@
       %p
         <code>--clean</code>: Run bundle clean automatically after install
       %p
-        <code>--deployment</code>: Install using defaults tuned for deployment environments
+        <code>--deployment</code>: Install using defaults tuned for deployment and CI environments
       %p
         <code>--frozen</code>: Do not allow the Gemfile.lock to be updated after this install
       %p
@@ -86,18 +86,23 @@
 
   .bullet#deployment
     .description
-      Install all dependencies on to a production server.
+      Install all dependencies onto a production or CI server.
       Do <b>not</b> use this flag on a development machine.
     :code
       $ bundle install --deployment
     .notes
       %p
-        The <code>--deployment</code> flag activates a number of deployment-friendly
-        conventions:
+        The <code>--deployment</code> flag activates a number of deployment- and
+        CI-friendly conventions:
 
       %ul
-        %li Isolate all gems into <code>vendor/bundle</code>
-        %li Require an up-to-date <code>Gemfile.lock</code>
+        %li
+          Isolate all gems into <code>vendor/bundle</code>
+          (equivalent to <code>--path vendor/bundle</code>)
+        %li
+          Require an up-to-date <code>Gemfile.lock</code>
+          (equivalent to <code>--frozen</code>)
+        %li Disable ANSI color output
         %li
           If <code>bundle package</code> was run, do not fetch gems
           from rubygems.org. Instead, only use gems in the checked


### PR DESCRIPTION
It wasn't clear to me that `--deployment` is also meant to be used for CI environments. This PR makes it clear and also explains a bit more what `--deployment` is doing.