### PR TITLE
Improve the documentation for `bundle gem` and surface it on the homepage

### DIFF
--- a/source/partials/_sidebar.haml
+++ b/source/partials/_sidebar.haml
@@ -20,6 +20,7 @@
   %ul
     %li= link_to 'bundle install', "/#{current_version}/bundle_install.html"
     %li= link_to 'bundle update', "/#{current_version}/bundle_update.html"
+    %li= link_to 'bundle gem', "/#{current_version}/bundle_gem.html"
     .buttons
       = link_to 'View all commands', "/#{current_version}/commands.html"
 

--- a/source/v1.10/bundle_gem.haml
+++ b/source/v1.10/bundle_gem.haml
@@ -12,10 +12,27 @@
       %p
         <code>--bin or -b</code>: Generate a binary for your library.
       %p
-        <code>--edit</code>: Opens generated gemspec with specified or default
-        text editor set BUNDLER_EDITOR, EDITOR or VISUAL env variables.
+        <code>--coc</code>: Generate a code of conduct file.
+      %p
+        <code>--edit</code>: Open generated gemspec in the specified editor (defaults to <code>$EDITOR</code> or <code>$BUNDLER_EDITOR</code>)
       %p
         <code>--ext</code>: Generate a skeleton for a C-extension.
       %p
+        <code>--mit</code>: Generate an MIT license file.
+      %p
         <code>--test</code>: Generate a test directory for your library:
-        'rspec' is the default, but 'minitest' is also supported.
+        <code>rspec</code> is the default, but <code>minitest</code> is also supported.
+    .notes
+      %p
+        When run for the first time, <code>bundle gem</code> will ask for your preferences regarding test framework, code of conduct, and MIT license. These preferences will be stored in <code>~/.bundle/config</code> for future runs.
+  .bullet
+    .description
+      The generated project will contain all the necessary boilerplate, including a README and a gemspec template. Also included will be a Rakefile with tasks suitable for gem development:
+    .how
+      :code
+        $ rake -T
+        rake build          # Build GEM-0.1.0.gem into the pkg directory
+        rake install        # Build and install GEM-0.1.0.gem into system gems
+        rake install:local  # Build and install GEM-0.1.0.gem into system gems without network access
+        rake release        # Create tag v0.1.0 and build and push GEM-0.1.0.gem to Rubygems
+        rake test           # Run tests

--- a/source/v1.10/index.haml
+++ b/source/v1.10/index.haml
@@ -85,7 +85,7 @@
 %h2#create-gem Create a rubygem with Bundler
 
 %p
-  Bundler is also the best way to create new gems. Just like you might create a standard Rails project using <code>rails new</code>, you can create a standard gem project with <code>bundle gem</code>.
+  Bundler is also an easy way to create new gems. Just like you might create a standard Rails project using <code>rails new</code>, you can create a standard gem project with <code>bundle gem</code>.
 
 .bullet
   .description

--- a/source/v1.10/index.haml
+++ b/source/v1.10/index.haml
@@ -82,6 +82,35 @@
       bundle, and will always work.
     = link_to 'Learn More: Executables', './man/bundle-exec.1.html'
 
+%h2#create-gem Create a rubygem with Bundler
+
+%p
+  Bundler is also the best way to create new gems. Just like you might create a standard Rails project using <code>rails new</code>, you can create a standard gem project with <code>bundle gem</code>.
+
+.bullet
+  .description
+    Create a new gem with a README, .gemspec, Rakefile, directory structure, and all the basic boilerplate you need to describe, test, and publish a gem:
+  :code
+    $ bundle gem my_gem
+    Creating gem 'my_gem'...
+          create  my_gem/Gemfile
+          create  my_gem/.gitignore
+          create  my_gem/lib/my_gem.rb
+          create  my_gem/lib/my_gem/version.rb
+          create  my_gem/my_gem.gemspec
+          create  my_gem/Rakefile
+          create  my_gem/README.md
+          create  my_gem/bin/console
+          create  my_gem/bin/setup
+          create  my_gem/CODE_OF_CONDUCT.md
+          create  my_gem/LICENSE.txt
+          create  my_gem/.travis.yml
+          create  my_gem/test/test_helper.rb
+          create  my_gem/test/my_gem_test.rb
+    Initializing git repo in ./my_gem
+
+  = link_to 'Learn More: bundle gem', './bundle_gem.html'
+
 %h2#use-bundler Use Bundler with
 .buttons
   = link_to 'Rails 3', './rails3.html'


### PR DESCRIPTION
`bundle gem` is the de-facto standard for creating rubygem projects, but this is not readily apparent by reading the current bundler.io site. This PR adds a section to the homepage explaining the `bundle gem` command, and improves the existing documentation.