### PR TITLE
Markdown extentions, set partials_dir, create base layout

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,6 +1,20 @@
 activate :syntax
 set :markdown_engine, :kramdown
 
+# Markdown extentions
+set :markdown,
+    autolink: true,
+    fenced_code_blocks: true,
+    footnotes: true,
+    gh_codeblock: true,
+    highlight: true,
+    no_intra_emphasis: true,
+    quote: true,
+    smartypants: true,
+    strikethrough: true,
+    superscript: true,
+    tables: true
+
 set :versions, `rake versions`.split
 set :current_version, versions.last
 

--- a/config.rb
+++ b/config.rb
@@ -39,6 +39,7 @@ Dir.glob(File.expand_path('../helpers/**/*.rb', __FILE__), &method(:require))
 set :css_dir, 'stylesheets'
 set :js_dir, 'javascripts'
 set :images_dir, 'images'
+set :partials_dir, 'partials'
 
 activate :blog do |blog|
   blog.name = 'blog'

--- a/source/layouts/base.haml
+++ b/source/layouts/base.haml
@@ -1,0 +1,29 @@
+!!! 5
+%html(lang="en")
+  %head
+    %meta(charset="utf-8")
+    %meta(http-equiv="X-UA-Compatible" content="IE=edge")
+    %meta(name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no")
+    %meta(name="globalsign-domain-verification" content="276VSYOko8B8vIu1i8i5qbj7_ql5PXo0dU69XQy-SL")
+
+    %title
+      - page_title = current_page.data.title
+      = "Bundler: #{ page_title || "The best way to manage a Ruby application's gems"}"
+
+    %link(rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans:400,700,400italic,700italic|Source+Code+Pro")
+
+    = yield_content :head
+
+    = stylesheet_link_tag "application"
+
+    = favicon_tag 'images/favicon.png'
+
+    = feed_tag :atom, "#{blog.options.prefix.to_s}/feed.xml", title: "Atom Feed"
+
+  %body{class: current_page.data.page_classes || ''}
+
+    ~ yield
+
+    = javascript_include_tag "application"
+
+    = yield_content :tail

--- a/source/layouts/blog_layout.haml
+++ b/source/layouts/blog_layout.haml
@@ -1,24 +1,19 @@
-!!!
 - v = current_page.url.scan(/v\d\.\d+/).first || current_version
-%html
-  %head
-    = partial 'partials/head'
-  %body
-    #body
-      #header
-        - logo_img = image_tag('gembundler.png', :width => 725, :alt => "The best way to manage your application's dependencies")
-        = link_to logo_img, '/', :class => 'image'
-      #container
-        .contents.blog
-          %h2.title
-            = link_to current_article.title, current_article.url
-          %h3.subtitle
-            by
-            = link_to current_article.data.author, current_article.data.author_url, :target => '_blank'
-            on
-            %time
-              = current_article.date.strftime('%b %e %Y')
-          %hr
-          = find_and_preserve do
-            = yield
-    = partial 'partials/footer', locals: { v: v }
+
+~ wrap_layout :base do
+  #body
+    = partial 'header'
+    #container
+      .contents.blog
+        %h2.title
+          = link_to current_article.title, current_article.url
+        %h3.subtitle
+          by
+          = link_to current_article.data.author, current_article.data.author_url, :target => '_blank'
+          on
+          %time
+            = current_article.date.strftime('%b %e %Y')
+        %hr
+        = find_and_preserve do
+          = yield
+  = partial 'partials/footer', locals: { v: v }

--- a/source/layouts/blog_layout.haml
+++ b/source/layouts/blog_layout.haml
@@ -1,5 +1,5 @@
 !!!
-- v = current_page.url.scan(/v\d\.\d/).first || current_version
+- v = current_page.url.scan(/v\d\.\d+/).first || current_version
 %html
   %head
     = partial 'partials/head'
@@ -13,7 +13,7 @@
           %h2.title
             = link_to current_article.title, current_article.url
           %h3.subtitle
-            by 
+            by
             = link_to current_article.data.author, current_article.data.author_url, :target => '_blank'
             on
             %time

--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -1,15 +1,10 @@
-!!!
 - v = current_page.url.scan(/v\d\.\d+/).first || current_version
-%html
-  %head
-    = partial 'partials/head'
-  %body
-    #body
-      #header
-        - logo_img = image_tag('gembundler.png', :width => 725, :alt => "The best way to manage your application's dependencies")
-        = link_to logo_img, '/', :class => 'image'
-      #container
-        #contents
-          = yield
-        = partial 'partials/sidebar' if v == current_version
-    = partial 'partials/footer', locals: { v: v }
+
+~ wrap_layout :base do
+  #body
+    = partial 'header'
+    #container
+      #contents
+        = yield
+      = partial 'sidebar' if v == current_version
+  = partial 'footer', locals: { v: v }

--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -1,5 +1,5 @@
 !!!
-- v = current_page.url.scan(/v\d\.\d/).first || current_version
+- v = current_page.url.scan(/v\d\.\d+/).first || current_version
 %html
   %head
     = partial 'partials/head'

--- a/source/partials/_head.haml
+++ b/source/partials/_head.haml
@@ -1,7 +1,0 @@
-%title
-  = "Bundler: #{current_page.data.title || "The best way to manage a Ruby application's gems"}" 
-%meta{'http-equiv' => 'Content-Type', 'content' => 'text/html; charset=UTF-8'}
-%meta{'name' => 'globalsign-domain-verification', 'content' => '276VSYOko8B8vIu1i8i5qbj7_ql5PXo0dU69XQy-SL'}
-= favicon_tag 'images/favicon.png'
-= stylesheet_link_tag 'application'
-= feed_tag :atom, "#{blog.options.prefix.to_s}/feed.xml", title: "Atom Feed"

--- a/source/partials/_header.haml
+++ b/source/partials/_header.haml
@@ -1,0 +1,3 @@
+#header
+  - logo_img = image_tag('gembundler.png', :width => 725, :alt => "The best way to manage your application's dependencies")
+  = link_to logo_img, '/', :class => 'image'


### PR DESCRIPTION
Highlights:
- Add markdown extention for features not available in standard markdown  
- Set partial directory for easy referencing. ie. `partial 'partials/header' to partial 'header'
- Create a base layout which all other layouts inherit from.