### PR TITLE
Show the submodules option in the git page

### DIFF
--- a/source/v1.10/git.haml
+++ b/source/v1.10/git.haml
@@ -73,6 +73,14 @@
 
   .bullet
     .description
+      Specify that the submodules from a git repository
+      also should be expanded by bundler
+    :code
+      # lang: ruby
+      gem 'rugged', :git => 'git://github.com/libgit2/rugged.git', :submodules => true
+
+  .bullet
+    .description
       If you are getting your gems from a public GitHub repository,
       you can use the shorthand
     :code


### PR DESCRIPTION
Hello,

I know that the `submodules` option for getting gems via git is documented in the [Gemfile manual](http://bundler.io/man/gemfile.5.html), but I think it would be nice to mention it in the [git page](http://bundler.io/git.html).

Also, I looked it up and it seems this feature exists since the 1.0 version, but I was not sure if I should change older docs. Can I add this info in the older docs too? I'd update this PR.

Thanks

