### PR TITLE
Fix anchor in links to RubyGems version specifiers page

### DIFF
--- a/source/v1.0/gemfile.haml
+++ b/source/v1.0/gemfile.haml
@@ -39,7 +39,7 @@
       <code>~> 2.0.3</code> is identical to <code>>= 2.0.3</code> and <code>< 2.1</code>.
       <code>~> 2.1</code> is identical to <code>>= 2.1</code> and <code>< 3.0</code>.
       <code>~> 2.2.beta</code> will match prerelease versions like <code>2.2.beta.12</code>.
-    = link_to("RubyGems version specifiers", "http://guides.rubygems.org/patterns/#pessimistic_version_constraint")
+    = link_to("RubyGems version specifiers", "http://guides.rubygems.org/patterns/#pessimistic-version-constraint")
 
   .bullet
     .description

--- a/source/v1.1/gemfile.haml
+++ b/source/v1.1/gemfile.haml
@@ -39,7 +39,7 @@
       <code>~> 2.0.3</code> is identical to <code>>= 2.0.3</code> and <code>< 2.1</code>.
       <code>~> 2.1</code> is identical to <code>>= 2.1</code> and <code>< 3.0</code>.
       <code>~> 2.2.beta</code> will match prerelease versions like <code>2.2.beta.12</code>.
-    = link_to 'RubyGems version specifiers', 'http://guides.rubygems.org/patterns/#pessimistic_version_constraint'
+    = link_to 'RubyGems version specifiers', 'http://guides.rubygems.org/patterns/#pessimistic-version-constraint'
 
   .bullet
     .description

--- a/source/v1.10/gemfile.haml
+++ b/source/v1.10/gemfile.haml
@@ -54,7 +54,7 @@
       <code>~> 2.0.3</code> is identical to <code>>= 2.0.3</code> and <code>< 2.1</code>.
       <code>~> 2.1</code> is identical to <code>>= 2.1</code> and <code>< 3.0</code>.
       <code>~> 2.2.beta</code> will match prerelease versions like <code>2.2.beta.12</code>.
-    = link_to 'RubyGems version specifiers', 'http://guides.rubygems.org/patterns/#pessimistic_version_constraint'
+    = link_to 'RubyGems version specifiers', 'http://guides.rubygems.org/patterns/#pessimistic-version-constraint'
 
   .bullet
     .description

--- a/source/v1.2/gemfile.haml
+++ b/source/v1.2/gemfile.haml
@@ -39,7 +39,7 @@
       <code>~> 2.0.3</code> is identical to <code>>= 2.0.3</code> and <code>< 2.1</code>.
       <code>~> 2.1</code> is identical to <code>>= 2.1</code> and <code>< 3.0</code>.
       <code>~> 2.2.beta</code> will match prerelease versions like <code>2.2.beta.12</code>.
-    = link_to 'RubyGems version specifiers', 'http://guides.rubygems.org/patterns/#pessimistic_version_constraint'
+    = link_to 'RubyGems version specifiers', 'http://guides.rubygems.org/patterns/#pessimistic-version-constraint'
 
   .bullet
     .description

--- a/source/v1.3/gemfile.haml
+++ b/source/v1.3/gemfile.haml
@@ -33,7 +33,7 @@
       <code>~> 2.0.3</code> is identical to <code>>= 2.0.3</code> and <code>< 2.1</code>.
       <code>~> 2.1</code> is identical to <code>>= 2.1</code> and <code>< 3.0</code>.
       <code>~> 2.2.beta</code> will match prerelease versions like <code>2.2.beta.12</code>.
-    = link_to 'RubyGems version specifiers', 'http://guides.rubygems.org/patterns/#pessimistic_version_constraint'
+    = link_to 'RubyGems version specifiers', 'http://guides.rubygems.org/patterns/#pessimistic-version-constraint'
 
   .bullet
     .description

--- a/source/v1.5/gemfile.haml
+++ b/source/v1.5/gemfile.haml
@@ -33,7 +33,7 @@
       <code>~> 2.0.3</code> is identical to <code>>= 2.0.3</code> and <code>< 2.1</code>.
       <code>~> 2.1</code> is identical to <code>>= 2.1</code> and <code>< 3.0</code>.
       <code>~> 2.2.beta</code> will match prerelease versions like <code>2.2.beta.12</code>.
-    = link_to 'RubyGems version specifiers', 'http://guides.rubygems.org/patterns/#pessimistic_version_constraint'
+    = link_to 'RubyGems version specifiers', 'http://guides.rubygems.org/patterns/#pessimistic-version-constraint'
 
   .bullet
     .description

--- a/source/v1.6/gemfile.haml
+++ b/source/v1.6/gemfile.haml
@@ -52,7 +52,7 @@
       <code>~> 2.0.3</code> is identical to <code>>= 2.0.3</code> and <code>< 2.1</code>.
       <code>~> 2.1</code> is identical to <code>>= 2.1</code> and <code>< 3.0</code>.
       <code>~> 2.2.beta</code> will match prerelease versions like <code>2.2.beta.12</code>.
-    = link_to 'RubyGems version specifiers', 'http://guides.rubygems.org/patterns/#pessimistic_version_constraint'
+    = link_to 'RubyGems version specifiers', 'http://guides.rubygems.org/patterns/#pessimistic-version-constraint'
 
   .bullet
     .description

--- a/source/v1.7/gemfile.haml
+++ b/source/v1.7/gemfile.haml
@@ -54,7 +54,7 @@
       <code>~> 2.0.3</code> is identical to <code>>= 2.0.3</code> and <code>< 2.1</code>.
       <code>~> 2.1</code> is identical to <code>>= 2.1</code> and <code>< 3.0</code>.
       <code>~> 2.2.beta</code> will match prerelease versions like <code>2.2.beta.12</code>.
-    = link_to 'RubyGems version specifiers', 'http://guides.rubygems.org/patterns/#pessimistic_version_constraint'
+    = link_to 'RubyGems version specifiers', 'http://guides.rubygems.org/patterns/#pessimistic-version-constraint'
 
   .bullet
     .description

--- a/source/v1.8/gemfile.haml
+++ b/source/v1.8/gemfile.haml
@@ -54,7 +54,7 @@
       <code>~> 2.0.3</code> is identical to <code>>= 2.0.3</code> and <code>< 2.1</code>.
       <code>~> 2.1</code> is identical to <code>>= 2.1</code> and <code>< 3.0</code>.
       <code>~> 2.2.beta</code> will match prerelease versions like <code>2.2.beta.12</code>.
-    = link_to 'RubyGems version specifiers', 'http://guides.rubygems.org/patterns/#pessimistic_version_constraint'
+    = link_to 'RubyGems version specifiers', 'http://guides.rubygems.org/patterns/#pessimistic-version-constraint'
 
   .bullet
     .description

--- a/source/v1.9/gemfile.haml
+++ b/source/v1.9/gemfile.haml
@@ -54,7 +54,7 @@
       <code>~> 2.0.3</code> is identical to <code>>= 2.0.3</code> and <code>< 2.1</code>.
       <code>~> 2.1</code> is identical to <code>>= 2.1</code> and <code>< 3.0</code>.
       <code>~> 2.2.beta</code> will match prerelease versions like <code>2.2.beta.12</code>.
-    = link_to 'RubyGems version specifiers', 'http://guides.rubygems.org/patterns/#pessimistic_version_constraint'
+    = link_to 'RubyGems version specifiers', 'http://guides.rubygems.org/patterns/#pessimistic-version-constraint'
 
   .bullet
     .description


### PR DESCRIPTION
I guess somewhere the anchor changed from [`#pessimistic_version_constraint`][1] to [`#pessimistic-version-constraint`][2]. This fixes all the links.

[1]: http://guides.rubygems.org/patterns/#pessimistic_version_constraint
[2]: http://guides.rubygems.org/patterns/#pessimistic-version-constraint