### PR TITLE
Fix typo of 'a' article before vowels

### DIFF
--- a/source/v1.10/gemfile.haml
+++ b/source/v1.10/gemfile.haml
@@ -111,7 +111,7 @@
 
   .bullet
     .description
-      If you would like to use a unpacked gem directly from the filesystem, simply set the <code>:path</code> option to the path containing the gem's files.
+      If you would like to use an unpacked gem directly from the filesystem, simply set the <code>:path</code> option to the path containing the gem's files.
     :code
       # lang: ruby
       gem 'extracted_library', :path => './vendor/extracted_library'

--- a/source/v1.11/gemfile.haml
+++ b/source/v1.11/gemfile.haml
@@ -111,7 +111,7 @@
 
   .bullet
     .description
-      If you would like to use a unpacked gem directly from the filesystem, simply set the <code>:path</code> option to the path containing the gem's files.
+      If you would like to use an unpacked gem directly from the filesystem, simply set the <code>:path</code> option to the path containing the gem's files.
     :code
       # lang: ruby
       gem 'extracted_library', :path => './vendor/extracted_library'

--- a/source/v1.3/gemfile.haml
+++ b/source/v1.3/gemfile.haml
@@ -70,7 +70,7 @@
 
   .bullet
     .description
-      If you would like to use a unpacked gem directly from the filesystem, simply set the <code>:path</code> option to the path containing the the gem's files.
+      If you would like to use an unpacked gem directly from the filesystem, simply set the <code>:path</code> option to the path containing the the gem's files.
     :code
       # lang: ruby
       gem 'extracted_library', :path => './vendor/extracted_library'

--- a/source/v1.5/gemfile.haml
+++ b/source/v1.5/gemfile.haml
@@ -70,7 +70,7 @@
 
   .bullet
     .description
-      If you would like to use a unpacked gem directly from the filesystem, simply set the <code>:path</code> option to the path containing the the gem's files.
+      If you would like to use an unpacked gem directly from the filesystem, simply set the <code>:path</code> option to the path containing the the gem's files.
     :code
       # lang: ruby
       gem 'extracted_library', :path => './vendor/extracted_library'

--- a/source/v1.6/gemfile.haml
+++ b/source/v1.6/gemfile.haml
@@ -89,7 +89,7 @@
 
   .bullet
     .description
-      If you would like to use a unpacked gem directly from the filesystem, simply set the <code>:path</code> option to the path containing the gem's files.
+      If you would like to use an unpacked gem directly from the filesystem, simply set the <code>:path</code> option to the path containing the gem's files.
     :code
       # lang: ruby
       gem 'extracted_library', :path => './vendor/extracted_library'

--- a/source/v1.9/gemfile.haml
+++ b/source/v1.9/gemfile.haml
@@ -111,7 +111,7 @@
 
   .bullet
     .description
-      If you would like to use a unpacked gem directly from the filesystem, simply set the <code>:path</code> option to the path containing the gem's files.
+      If you would like to use an unpacked gem directly from the filesystem, simply set the <code>:path</code> option to the path containing the gem's files.
     :code
       # lang: ruby
       gem 'extracted_library', :path => './vendor/extracted_library'


### PR DESCRIPTION
I'm not a native English speaking person, but AFAIK "an" article is used in preference to "a" one when it goes before vowel letters or sounds. At least, my tongue stumbled when I passed that place while reading documentation. :)

Hope, this PR will be helpful.