### PR TITLE
Fixes mixed content warning/blocking when https

### DIFF
--- a/source/partials/_footer.haml
+++ b/source/partials/_footer.haml
@@ -9,7 +9,7 @@
   .spacer
   = image_tag 'bundler-small.png'
 %a#github{ :href => 'http://github.com/bundler/bundler/' }
-  %img{ :src => 'http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png', :alt => 'Fork me on GitHub' }
+  %img{ :src => 'https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png', :alt => 'Fork me on GitHub' }
 #prod-versions
   Docs:
   = link_to("Previous Version (#{versions[-2]})", "/#{versions[-2]}/index.html", :class => ('current' if v == versions[-2]))

--- a/source/stylesheets/application.scss
+++ b/source/stylesheets/application.scss
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Source+Code+Pro:400,600);
+@import url(https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600);
 
 @import "compass/css3";
 @import "normalize";


### PR DESCRIPTION
* 'forkme' image makes Firefox/Chrome display a warning
* In the case of the font, it is not being loaded by Firefox/Chrome given it is
  considered as active (not passive) mixed content

![bundler-site-mixed-content-warning](https://cloud.githubusercontent.com/assets/456459/14906080/ef1f21c0-0d8d-11e6-8dfe-fe618c6f362d.png)
