### PR TITLE
Add version 1.12 link to shared "what's new" banner

### DIFF
--- a/source/shared/_whats_new.haml
+++ b/source/shared/_whats_new.haml
@@ -1,6 +1,7 @@
 %h1 What's New in each Release
 .buttons
-  = link_to 'v1.11', '/v1.11/whats_new.html'
+  = link_to 'v1.12', '/v1.12/whats_new.html#version112'
+  = link_to 'v1.11', '/v1.11/whats_new.html#version111'
   = link_to 'v1.10', '/v1.10/whats_new.html#version110'
   = link_to 'v1.9', '/v1.9/whats_new.html#version19'
   = link_to 'v1.8', '/v1.8/whats_new.html#version18'

--- a/source/v1.12/whats_new.haml
+++ b/source/v1.12/whats_new.haml
@@ -1,6 +1,6 @@
 = partial "shared/whats_new"
 
-%h2#version111 What's New in v1.12
+%h2#version112 What's New in v1.12
 
 %h3 New index format
 


### PR DESCRIPTION
- Fix html id for `v1.12`