### PR TITLE
Warn about two factor auth and tokens for password input in site deploy rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -78,6 +78,13 @@ task :release => [:build, :update_site] do
     sh "git commit -m 'bundler/bundler-site@#{commit}'"
 
     Bundler.with_clean_env do
+      puts <<-TWO_FACTOR_WARNING
+====================================================================
+Please note that if you have two-factor auth enabled for your Github
+account, you will need to use a github access token instead of your
+account password.
+====================================================================
+      TWO_FACTOR_WARNING
       sh "git push origin master"
     end
   end


### PR DESCRIPTION
- This caveat is not clear from the script and failure to enter in the correct credentials at this point in the deploy script can result in multiple commits being pushed in the eventual deploy.