### PR TITLE
Fix contributors page rendering for Safari

### DIFF
--- a/source/contributors.html.haml
+++ b/source/contributors.html.haml
@@ -4,14 +4,6 @@
     class: 'img-responsive header-padding',
     style: 'max-width: 460px; padding-bottom: 10px; width: 78%;'
 
-:css
-  .polygon-clip-hexagon {
-    -webkit-clip-path: polygon(25% 6%, 75% 6%, 100% 50%, 75% 94%, 25% 94%, 0% 50%);
-    clip-path: polygon(25% 6%, 75% 6%, 100% 50%, 75% 94%, 25% 94%, 0% 50%);
-    -webkit-clip-path: url(#polygon);
-    clip-path: url(#polygon);
-  }
-
 .row.docs
   .container
     .col-xs-6.col-md-4
@@ -58,9 +50,3 @@
           %h4
             %b Tim Moore
           %h5= link_to '@TimMoore', 'https://github.com/TimMoore'
-
--#definitions for hexagon-ing square image with CSS
-%svg.clip-svg{style: 'position: absolute;'}
-  %defs
-    %clipPath#polygon{:clipPathUnits => 'objectBoundingBox'}
-      %polygon{:points => '0.25 0.06, 0.75 0.06, 1 0.5, 0.75 0.94, 0.25 0.94, 0 0.5'}

--- a/source/stylesheets/_hexagon_image.scss
+++ b/source/stylesheets/_hexagon_image.scss
@@ -25,3 +25,8 @@
     display: block;
   }
 }
+
+.polygon-clip-hexagon {
+  -webkit-clip-path: polygon(25% 6%, 75% 6%, 100% 50%, 75% 94%, 25% 94%, 0% 50%);
+  clip-path: polygon(25% 6%, 75% 6%, 100% 50%, 75% 94%, 25% 94%, 0% 50%);
+}


### PR DESCRIPTION
I noticed that the contributors page wasn't rendering correctly in
Safari on my iPhone -- the first team member's face/name show ups, and
then after that there is only white, no other team members or footer.

I think the issue is that there are multiple, conflicting strategies for
"clipping" the profile photos into hexagons, and there's some kind of
clash there.

With this change, the page renders correctly for Safari and Chrome. On
Firefox, the page will render, but it no longer has hexagon-clipped
profile photos. According to http://bennettfeely.com/clippy/ the
clip-path property doesn't work in Firefox, although the previous
implementation did manage to get it working by embedding an svg in the
HTML and then loading that.

IMO losing the hexagon-clipping on Firefox is worth it for the page to
render in Safari, although admittedly that calculus is subjective.

(I also haven't checked to see how other browsers are affected.)