### PR TITLE
Readd html clipPath in Team page only for Firefox

### DIFF
--- a/source/contributors.html.haml
+++ b/source/contributors.html.haml
@@ -4,6 +4,12 @@
     class: 'img-responsive header-padding',
     style: 'max-width: 460px; padding-bottom: 10px; width: 78%;'
 
+:css
+  .polygon-clip-hexagon {
+    clip-path: polygon(25% 6%, 75% 6%, 100% 50%, 75% 94%, 25% 94%, 0% 50%);
+    clip-path: url(#polygon);
+  }
+
 .row.docs
   .container
     .col-xs-6.col-md-4
@@ -50,3 +56,8 @@
           %h4
             %b Tim Moore
           %h5= link_to '@TimMoore', 'https://github.com/TimMoore'
+
+%svg.clip-svg{style: 'position: absolute;'}
+  %defs
+    %clipPath#polygon{:clipPathUnits => 'objectBoundingBox'}
+      %polygon{:points => '0.25 0.06, 0.75 0.06, 1 0.5, 0.75 0.94, 0.25 0.94, 0 0.5'}


### PR DESCRIPTION
It works for me in Firefox (v47 and v49), Safari i Chrome.

Fixes error on Firefox from #223 