### PR TITLE
updated documentation for outdated utility

### DIFF
--- a/source/v1.12/bundle_outdated.html.md
+++ b/source/v1.12/bundle_outdated.html.md
@@ -2,7 +2,7 @@
 
 List installed gems with newer versions available
 
-    $ bundle outdated [GEM] [--local] [--pre] [--source] [--strict]
+    $ bundle outdated [GEM] [--local] [--pre] [--source] [--strict] [--major] [--minor] [--patch] [--parseable]
     
 Options:
 
@@ -13,6 +13,14 @@ Options:
 <code>--source</code>: Check against a specific source
 
 <code>--strict</code>: Display outdated gems that match the dependency requirements.
+
+<code>--major</code>: Display gems with a major version update
+
+<code>--minor</code>: Display gems with a minor version update
+
+<code>--patch</code>: Display gems with a patch version update
+
+<code>--parseable</code>: Disaply the output in a machine-readable format
 
 Outdated lists the names and versions of gems that have a newer version available
 in the given source. Calling outdated with [GEM [GEM]] will only check for newer


### PR DESCRIPTION
Adds documentation for the `--major` `--minor` `--patch` and `--parseable` options that were added to the `outdated` utility in v1.12. Closes #217 

I noticed that @kruczjak converted all the docs to markdown in #230 - I can make a branch off that PR if you want to merge in the markdown conversion first. 