### PR TITLE
Fix typo in bundle outdated in 1.12

### DIFF
--- a/source/v1.12/bundle_outdated.html.md
+++ b/source/v1.12/bundle_outdated.html.md
@@ -25,7 +25,7 @@ Options:
 
 <code>--patch</code>: Display gems with a patch version update
 
-<code>--parseable</code>: Disaply the output in a machine-readable format
+<code>--parseable</code>: Display the output in a machine-readable format
 
 Outdated lists the names and versions of gems that have a newer version available
 in the given source. Calling outdated with [GEM [GEM]] will only check for newer


### PR DESCRIPTION
Fix small typo in `bundle outdated` documentation with version 1.12