### PR TITLE
Fix broken links to "Learn More: Packing"

### DIFF
--- a/source/v1.12/deploying.html.md
+++ b/source/v1.12/deploying.html.md
@@ -31,7 +31,7 @@ with the exact same gems you use in development.
 If you have run <code>bundle package</code>, the cached
 gems will be used automatically.
 
-<a href="/bundle_package.html" class="btn btn-primary">Learn More: Packing</a>
+<a href="/man/bundle-package.1.html" class="btn btn-primary">Learn More: Packing</a>
 
 ### Automatic deployment with Capistrano
 

--- a/source/v1.13/deploying.html.haml
+++ b/source/v1.13/deploying.html.haml
@@ -32,7 +32,7 @@
           If you have run <code>bundle package</code>, the cached
           gems will be used automatically.
 
-        = link_to 'Learn More: Packing', './bundle_package.html', class: 'btn btn-primary'
+        = link_to 'Learn More: Packing', '/man/bundle-package.1.html', class: 'btn btn-primary'
 
     .bullet
       %h3 Automatic deployment with Capistrano


### PR DESCRIPTION
Aims to fix the broken `Learn More: Packing`links on http://bundler.io/deploying.html and https://bundler.io/v1.12/deploying.html