### PR TITLE
Make command line usage denotation consistent

### DIFF
--- a/source/issues.html.md
+++ b/source/issues.html.md
@@ -28,37 +28,37 @@ list](http://bundler.io/compatibility.html), and make sure that the version of B
 using works with the versions of Ruby and Rubygems that you are using. To see your versions:
 
     # Bundler version
-    bundle -v
+    $ bundle -v
 
     # Ruby version
-    ruby -v
+    $ ruby -v
 
     # Rubygems version
-    gem -v
+    $ gem -v
 
 If these instructions don't work, or you can't find any appropriate instructions, you can try these troubleshooting steps:
 
     # Remove user-specific gems and git repos
-    rm -rf ~/.bundle/ ~/.gem/bundler/ ~/.gems/cache/bundler/
+    $ rm -rf ~/.bundle/ ~/.gem/bundler/ ~/.gems/cache/bundler/
 
     # Remove system-wide git repos and git checkouts
-    rm -rf $GEM_HOME/bundler/ $GEM_HOME/cache/bundler/
+    $ rm -rf $GEM_HOME/bundler/ $GEM_HOME/cache/bundler/
 
     # Remove project-specific settings
-    rm -rf .bundle/
+    $ rm -rf .bundle/
 
     # Remove project-specific cached gems and repos
-    rm -rf vendor/cache/
+    $ rm -rf vendor/cache/
 
     # Remove the saved resolve of the Gemfile
-    rm -rf Gemfile.lock
+    $ rm -rf Gemfile.lock
 
     # Uninstall the rubygems-bundler and open_gem gems
-    rvm gemset use global # if using rvm
-    gem uninstall rubygems-bundler open_gem
+    $ rvm gemset use global # if using rvm
+    $ gem uninstall rubygems-bundler open_gem
 
     # Try to install one more time
-    bundle install
+    $ bundle install
 
 ## Reporting unresolved problems
 

--- a/source/localizable/v1.13/guides/creating_gem.en.html.md
+++ b/source/localizable/v1.13/guides/creating_gem.en.html.md
@@ -36,14 +36,14 @@ This guide was made using version 1.9.0 of bundler. We can follow along with oth
 we might not get the exact same output.  To check which version of bundler we currently have, 
 lets run the following command:
 
-    bundle -v
+    $ bundle -v
 
 We should see something close to `Bundler version 1.9.0`.  If necessary, we can update to the 
 newest version of Bundler by running `gem update bundler`.
 
 To begin to create a gem using Bundler, use the `bundle gem` command like this:
 
-    bundle gem foodie
+    $ bundle gem foodie
 
 We call our gem `foodie` because this gem is going to do a couple of things around food, such as 
 portraying them as either "Delicious!" or "Gross!". Stay tuned.
@@ -335,7 +335,7 @@ same thing, but we pass that value in as an option rather than an argument.
 To run this feature, we use the `cucumber` command, but of course because it's available within
 the context of our bundle, we use `bundle exec cucumber` like this:
 
-    bundle exec cucumber features/
+    $ bundle exec cucumber features/
 
 See those yellow things? They're undefined steps:
 
@@ -380,7 +380,7 @@ If this file was completely empty, we would run into a non-friendly `Errno::ENOE
 speaking of running, we should `chmod` this file to be an executable from our terminal:
 
 ~~~ bash
-chmod +x exe/foodie
+$ chmod +x exe/foodie
 ~~~
 
 Alright so we've got the executable file, now what? If we re-run our features we get *nothing*
@@ -691,8 +691,8 @@ Amazing stuff, hey?
 If we haven't already, we should commit all the files for our repository:
 
 ~~~ bash
-git add .
-git commit -m "The beginnings of the foodie gem"
+$ git add .
+$ git commit -m "The beginnings of the foodie gem"
 ~~~
 
 This is because the `foodie.gemspec` file uses `git ls-files` to detect which files should be 
@@ -724,15 +724,15 @@ whatever we see fit, make another commit to GitHub with a useful message such as
 
 If we want to make this process a little easier we could install the "gem-release" gem with:
 
-    gem install gem-release
+    $ gem install gem-release
 
 This gem provides several methods for helping with gem development in general, but most helpful 
 is the `gem bump` command which will bump the gem version to the next patch level. This method 
 also takes options to do these things:
 
-    gem bump --version minor # bumps to the next minor version
-    gem bump --version major # bumps to the next major version
-    gem bump --version 1.1.1 # bumps to the specified version
+    $ gem bump --version minor # bumps to the next minor version
+    $ gem bump --version major # bumps to the next major version
+    $ gem bump --version 1.1.1 # bumps to the specified version
 
 For more information, check out the ["gem-release" GitHub repository 
 homepage](http://github.com/svenfuchs/gem-release).

--- a/source/localizable/v1.13/guides/creating_gem.pl.html.md
+++ b/source/localizable/v1.13/guides/creating_gem.pl.html.md
@@ -27,13 +27,13 @@ Ta instrukcja została stworzona używając wersji 1.9.0 Bundler'a. Możesz kont
 możesz nie otrzymać takiego samego wyniku. Żeby sprawdzić jaka wersja bundler'a jest aktualnie zainstalowana,
 uruchom poniższą komendę:
 
-    bundle -v
+    $ bundle -v
 
 Jeśli to potrzebne, możesz zaktualizować Bundler'a do najnowszej wersji wpisując `gem install bundler`.
 
 Aby rozpocząć tworzenie nowego gem'a, użyj komendy `bundle gem` tak jak niżej:
 
-    bundle gem foodie
+    $ bundle gem foodie
 
 Nasz gem będzie się nazywał `foodie`, ponieważ będzie robił kilka rzeczy związanych z jedzeniem,
 np. określając je jako "Delicious!" lub "Gross!".

--- a/source/localizable/v1.13/guides/using_bundler_in_application.en.html.md
+++ b/source/localizable/v1.13/guides/using_bundler_in_application.en.html.md
@@ -31,12 +31,12 @@ will automatically init Bundler.**
 
 Firstly, we need to install Bundler.
  
-    gem install bundler
+    $ gem install bundler
     
 This command will also update already installed bundler. You should get something similar as output:
 
 ~~~ bash
-[kruczjak:~/git] % gem install bundler
+$ gem install bundler
 Successfully installed bundler-1.12.5
 1 gem installed
 ~~~
@@ -171,7 +171,7 @@ This Gemfile.lock is described in [next chapter](#gemfilelock).
 For deployment you should use
 [`--deployment` option](/man/bundle-install.1.html#DEPLOYMENT-MODE):
 
-    bundle install --deployment
+    $ bundle install --deployment
     
 This will install all dependencies to `./vendor/bundle`.
 
@@ -229,9 +229,9 @@ Let's break it down:
 
 Let's see examples first:
 
-    bundle exec rspec
+    $ bundle exec rspec
     
-    bundle exec rails s
+    $ bundle exec rails s
 
 This will allow you to run command (`rspec` and `rails s` here) in current bundle context,
 making all gems in Gemfile available to `require` and use.
@@ -244,7 +244,7 @@ To learn more about `bundle exec` command click [here](/man/bundle-exec.1.html).
 
 Now let's update some gems. With `bundle outdated` we can list installed gems with newer versions available:
 
-    [kruczjak:~/git] % bundle outdated
+    $ bundle outdated
     Fetching gem metadata from https://rubygems.org/
     Fetching version metadata from https://rubygems.org/
     Fetching dependency metadata from https://rubygems.org/
@@ -259,7 +259,7 @@ We've got `nokogiri` locked on version 1.6.7.2. How can we update it?
 `bundle install` won't install newer version because it's locked in `Gemfile.lock` file.
 We must use `bundle update`.
 
-    [kruczjak:~/git] % bundle update
+    $ bundle update
     Fetching git://github.com/middleman/middleman-syntax.git
     Fetching gem metadata from https://rubygems.org/
     Fetching version metadata from https://rubygems.org/

--- a/source/localizable/v1.13/guides/using_bundler_in_application.pl.html.md
+++ b/source/localizable/v1.13/guides/using_bundler_in_application.pl.html.md
@@ -29,12 +29,12 @@ Bundler zostanie automatycznie zainicjalizowany**
 
 Po pierwsze, musimy zainstalować Bundler-a.
  
-    gem install bundler
+    $ gem install bundler
     
 Powyższa komenda zaktualizuje Bundler-a, jeśli był wcześniej zainstalowany. Powinniśmy dostać coś takiego, jako wynik:
 
 ~~~ bash
-[kruczjak:~/git] % gem install bundler
+$ gem install bundler
 Successfully installed bundler-1.12.5
 1 gem installed
 ~~~
@@ -168,7 +168,7 @@ Ten plik będzie omawiany w [następnym rozdziale](#gemfilelock).
 Dla deployment-u powinniśmy użyć
 [opcji `--deployment`](/man/bundle-install.1.html#DEPLOYMENT-MODE):
 
-    bundle install --deployment
+    $ bundle install --deployment
     
 Zainstaluje nam to wszystkie zależności do folderu `./vendor/bundle`.
 
@@ -226,9 +226,9 @@ Prześledźmy jego ważniejsze elementy:
 
 Popatrzmy najpierw na przykład:
 
-    bundle exec rspec
+    $ bundle exec rspec
     
-    bundle exec rails s
+    $ bundle exec rails s
 
 Dzięki temu, komenda (w tym przypadku `rspec` i `rails s`) zostanie uruchomiona w aktualnym kontekście bundle-a, 
 pozwalając dołączać i używać wszystkich gem-ów zdefiniowanych w `Gemfile`-u.
@@ -241,7 +241,7 @@ Czytaj więcej o komendzie `bundle exec` [tu](/man/bundle-exec.1.html).
 
 Now let's update some gems. With `bundle outdated` we can list installed gems with newer versions available:
 
-    [kruczjak:~/git] % bundle outdated
+    $ bundle outdated
     Fetching gem metadata from https://rubygems.org/
     Fetching version metadata from https://rubygems.org/
     Fetching dependency metadata from https://rubygems.org/
@@ -256,7 +256,7 @@ We've got `nokogiri` locked on version 1.6.7.2. How can we update it?
 `bundle install` won't install newer version because it's locked in `Gemfile.lock` file.
 We must use `bundle update`.
 
-    [kruczjak:~/git] % bundle update
+    $ bundle update
     Fetching git://github.com/middleman/middleman-syntax.git
     Fetching gem metadata from https://rubygems.org/
     Fetching version metadata from https://rubygems.org/

--- a/source/v1.13/git.html.haml
+++ b/source/v1.13/git.html.haml
@@ -147,13 +147,13 @@
         instead of using the remote version. This can be achieved by setting
         up a local override:
       :code
-        bundle config local.GEM_NAME /path/to/local/git/repository
+        $ bundle config local.GEM_NAME /path/to/local/git/repository
 
     .bullet
       .description
         For example, in order to use a local Rack repository, a developer could call:
       :code
-        bundle config local.rack ~/Work/git/rack
+        $ bundle config local.rack ~/Work/git/rack
       .description
         and setup the git repo pointing to a branch:
       :code
@@ -190,4 +190,4 @@
       .description
         %p If you do not want bundler to make these branch checks, you can override it by setting this option:
       :code
-        bundle config disable_local_branch_check true
+        $ bundle config disable_local_branch_check true


### PR DESCRIPTION
Throughout the website the use of some example commands are denoted with a `$` while other examples are not denoted. This PR is making the use of the denotation consistent throughout the site.

Let me know what you think.

Thanks!