### PR TITLE
remove require: spec, and update rack version where mentioned

### DIFF
--- a/source/localizable/index.html.haml
+++ b/source/localizable/index.html.haml
@@ -35,8 +35,8 @@
             # lang: ruby
             source 'https://rubygems.org'
             gem 'nokogiri'
-            gem 'rack', '~>1.1'
-            gem 'rspec', :require => 'spec'
+            gem 'rack', '~> 2.0.1'
+            gem 'rspec'
           %p.center-on-xs
             = link_to t('home.learn_more_gemfile'), './gemfile.html', class: 'btn btn-primary btn-lg pull-right btn-responsive'
         .clearfix

--- a/source/v1.13/bundler_workflow.html.haml
+++ b/source/v1.13/bundler_workflow.html.haml
@@ -71,8 +71,8 @@
         # lang: ruby
         source 'https://rubygems.org'
         gem 'nokogiri'
-        gem 'rack', '~>1.1'
-        gem 'rspec', :require => 'spec'
+        gem 'rack', '~> 2.0.1'
+        gem 'rspec'
 
       .notes
         This <code>Gemfile</code> says a few things. First, it says that bundler should

--- a/source/v1.13/gemfile.html.haml
+++ b/source/v1.13/gemfile.html.haml
@@ -65,7 +65,7 @@
         If a gem's main file is different than the gem name, specify how to require it.
       :code
         # lang: ruby
-        gem 'rspec', :require => 'spec'
+        gem 'rspec'
         gem 'sqlite3'
       .description
         Specify <code>:require => false</code> to prevent bundler from requiring the gem, but still install it and maintain dependencies.

--- a/source/v1.13/index.html.haml
+++ b/source/v1.13/index.html.haml
@@ -32,8 +32,8 @@
       # lang: ruby
       source 'https://rubygems.org'
       gem 'nokogiri'
-      gem 'rack', '~>1.1'
-      gem 'rspec', :require => 'spec'
+      gem 'rack', '~> 2.0.1'
+      gem 'rspec'
     = link_to 'Learn More: Gemfiles', './gemfile.html', class: 'btn btn-primary'
 
   .bullet


### PR DESCRIPTION
On the home page and several other pages there are examples of Gemfiles like:
```
source 'https://rubygems.org'
gem 'nokogiri'
gem 'rack', '~>1.1'
gem 'rspec', :require => 'spec'
```

This does not work, RSpec have removed `spec` since this documentation was written.

```
/Users/c/.gem/ruby/2.3.1/gems/bundler-1.13.6/lib/bundler/runtime.rb:91:in `require': cannot load such file -- spec (LoadError)
	from /Users/c/.gem/ruby/2.3.1/gems/bundler-1.13.6/lib/bundler/runtime.rb:91:in `block (2 levels) in require'
	from /Users/c/.gem/ruby/2.3.1/gems/bundler-1.13.6/lib/bundler/runtime.rb:86:in `each'
	from /Users/c/.gem/ruby/2.3.1/gems/bundler-1.13.6/lib/bundler/runtime.rb:86:in `block in require'
	from /Users/c/.gem/ruby/2.3.1/gems/bundler-1.13.6/lib/bundler/runtime.rb:75:in `each'
	from /Users/c/.gem/ruby/2.3.1/gems/bundler-1.13.6/lib/bundler/runtime.rb:75:in `require'
	from /Users/c/.gem/ruby/2.3.1/gems/bundler-1.13.6/lib/bundler.rb:106:in `require'
	from test.rb:3:in `<main>'
```

This PR removes the `:require => "spec"` and also updates the version of rack.

Thanks.