### PR TITLE
Add favicon markup in page layout

### DIFF
--- a/source/layouts/base.haml
+++ b/source/layouts/base.haml
@@ -5,6 +5,8 @@
     %meta(http-equiv="X-UA-Compatible" content="IE=edge")
     %meta(name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no")
     %meta(name="globalsign-domain-verification" content="276VSYOko8B8vIu1i8i5qbj7_ql5PXo0dU69XQy-SL")
+    %link(rel="icon" type="image/png" href="images/favicon-32x32.png" sizes="32x32")
+    %link(rel="icon" type="image/png" href="images/favicon-16x16.png" sizes="16x16")
     %title
       - page_title = current_page.data.title
       = "Bundler: #{ page_title || "The best way to manage a Ruby application's gems" }"


### PR DESCRIPTION
This is a very small change, i have added the markup of the favicons. It looks the markdown was used but was removed at some point.