### PR TITLE
cleanup git documentation on latest version

### DIFF
--- a/source/v1.13/git.html.haml
+++ b/source/v1.13/git.html.haml
@@ -4,14 +4,13 @@
   .contents
     .bullet
       .description
-        Bundler adds the ability to use gems directly from git repositories. Setting
-        them up is as easy as adding a gem to your Gemfile. Using the very latest
-        version of a gem (or even a fork) is just as easy as using an official
-        release.
-      .description
-        Because RubyGems lacks the ability to handle gems from git, any gems
-        installed from a git repository will not show up in <code>gem list</code>.
-        They will, however, be available after running <code>Bundler.setup</code>.
+        %p
+          Bundler has the ability to install gems directly from git repositories. Installing
+          a gem using git is as easy as adding a gem to your Gemfile.
+        %p
+          Note that because RubyGems lacks the ability to handle gems from git, any gems
+          installed from a git repository will not show up in <code>gem list</code>.
+          They will, however, be available after running <code>Bundler.setup</code>.
 
     .bullet
       .description
@@ -19,8 +18,7 @@
         repository with a .gemspec at its root
       :code
         # lang: ruby
-        gem 'nokogiri', :git => 'https://github.com/sparklemotion/nokogiri.git'
-
+        gem 'rack', :git => 'https://github.com/rack/rack'
     .bullet
       .description
         If there is no .gemspec at the root of
@@ -29,8 +27,7 @@
         dependencies
       :code
         # lang: ruby
-        gem 'deep_merge', '1.0', :git => 'https://github.com/peritor/deep_merge.git'
-
+        gem 'nokogiri', '1.7.0.1', :git => 'https://github.com/sparklemotion/nokogiri'
     .bullet
       .description
         Specify that a git repository containing
@@ -40,20 +37,17 @@
         # lang: ruby
         git 'https://github.com/rails/rails.git' do
           gem 'railties'
-          gem 'action_pack'
-          gem 'active_model'
+          gem 'actionpack'
+          gem 'activemodel'
         end
-
     .bullet
       .description
-        Specify that a git repository should use
-        a particular ref, branch, or tag
+        From the previous example, you may specify a particular ref, branch or tag
       :code
         # lang: ruby
-        :git => 'https://github.com/rails/rails.git', :ref => '4aded'
-        :git => 'https://github.com/rails/rails.git', :branch => '5-0-stable'
-        :git => 'https://github.com/rails/rails.git', :tag => 'v5.0.0'
-
+        git 'https://github.com/rails/rails.git', :ref => '4aded' do
+        git 'https://github.com/rails/rails.git', :branch => '5-0-stable' do
+        git 'https://github.com/rails/rails.git', :tag => 'v5.0.0' do
     .bullet
       .description
         Specifying a ref, branch, or tag for a
@@ -61,17 +55,17 @@
         exactly the same way
       :code
         # lang: ruby
-        gem 'nokogiri', :git => 'https://github.com/sparklemotion/nokogiri.git', :ref => '0eec4'
-
+        gem 'nokogiri', :git => 'https://github.com/rack/rack.git', :ref => '0bd839d'
+        gem 'nokogiri', :git => 'https://github.com/rack/rack.git', :tag => '2.0.1'
+        gem 'nokogiri', :git => 'https://github.com/rack/rack.git', :branch => 'rack-1.5'
     .bullet
       .description
         Bundler can use HTTP(S), SSH, or git
       :code
         # lang: ruby
-        gem 'nokogiri', :git => 'https://github.com/sparklemotion/nokogiri.git'
-        gem 'nokogiri', :git => 'git@github.com:sparklemotion/nokogiri.git'
-        gem 'nokogiri', :git => 'git://github.com/sparklemotion/nokogiri.git'
-
+        gem 'rack', :git => 'https://github.com/rack/rack.git'
+        gem 'rack', :git => 'git@github.com:rack/rack.git'
+        gem 'rack', :git => 'git://github.com/rack/rack.git'
     .bullet
       .description
         Specify that the submodules from a git repository
@@ -79,14 +73,13 @@
       :code
         # lang: ruby
         gem 'rugged', :git => 'git://github.com/libgit2/rugged.git', :submodules => true
-
     .bullet
       .description
         If you are getting your gems from a public GitHub repository,
         you can use the shorthand
       :code
         # lang: ruby
-        gem 'nokogiri', :github => 'sparklemotion/nokogiri'
+        gem 'rack', :github => 'rack/rack'
       .description
         If the repository name is the same as the GitHub account hosting it,
         you can omit it
@@ -109,8 +102,6 @@
         # lang: ruby
         gem 'capistrano-sidekiq', :github => 'seuros/capistrano-sidekiq'
         gem 'keystone', :bitbucket => 'musicone/keystone'
-
-
   %h2 Custom git sources
   .contents
     .bullet
@@ -127,7 +118,6 @@
         # lang: ruby
         git_source(:stash){ |repo_name| "https://stash.corp.acme.pl/\#{repo_name}.git" }
         gem 'rails', :stash => 'forks/rails'
-
   %h2 Security
   .contents
     .bullet
@@ -148,7 +138,6 @@
         up a local override:
       :code
         $ bundle config local.GEM_NAME /path/to/local/git/repository
-
     .bullet
       .description
         For example, in order to use a local Rack repository, a developer could call:
@@ -159,7 +148,6 @@
       :code
         # lang: ruby
         gem 'rack', :github => 'rack/rack', :branch => 'master'
-
     .bullet
       .description
         %p


### PR DESCRIPTION
This PR cleans up the Using Git documentation. Changes include:
- Added paragraph spacing where appropriate
- Rework content to be more clear and remove redundant sentences
- Use gems that can actually be installed via git (nokogiri has no gemfile and cannot be installed without the version)
- Remove extra padding on code/usage examples
- Deep merge repo no longer exists, use nokogiri instead as example gem with no .gemfile
- action_pack & active_model have been renamed to actionpack and activemodel
- fix git source example with ref, branch, tag options

Thanks.
