### PR TITLE
Add repository link in header

### DIFF
--- a/source/layouts/_navbar.haml
+++ b/source/layouts/_navbar.haml
@@ -18,3 +18,4 @@
         %li= link_to t('navbar.docs'), '/docs.html'
         %li= link_to t('navbar.team'), '/contributors.html'
         %li= link_to t('navbar.blog'), '/blog'
+        %li= link_to t('navbar.repository'), "https://github.com/bundler/bundler"


### PR DESCRIPTION
I think the link in footer is not easily accessible.