### PR TITLE
Rake task to create new minor version

### DIFF
--- a/lib/tasks/versions.rake
+++ b/lib/tasks/versions.rake
@@ -1,3 +1,7 @@
+require 'date'
+require 'erb'
+require 'pathname'
+
 VERSIONS = Dir.chdir("source") { Dir.glob("v*").sort_by{|x| [x.size, x] } }.freeze
 
 desc "Print the Bundler versions the site documents"
@@ -6,13 +10,27 @@ task :versions do
 end
 
 namespace :versions do
-  desc "Prepare a new version"
+  desc "Prepare a new minor version"
   task :create do
     last = VERSIONS.last
     succ = VERSIONS.last.succ
     puts "Latest version is #{last}. Creating version #{succ}..."
     cp_r "source/#{last}", "source/#{succ}"
     cp_r "source/localizable/#{last}", "source/localizable/#{succ}"
+    puts "Creating empty What's New page..."
+    render_whats_new(succ)
+    puts "Creating announcement blog post..."
     sh "middleman article 'Bundler #{succ}'"
   end
+end
+
+def render_whats_new(full_version)
+  version = full_version[1..-1]
+  version_slug = version.tr('.', '-')
+  date_slug = Date.today.strftime('%Y/%m/%d')
+
+  template = Pathname.new("../templates/whats_new.html.haml.erb").expand_path(__dir__)
+  renderer = ERB.new(template.read)
+  whats_new = Pathname.new("../../source/#{full_version}/whats_new.html.haml").expand_path(__dir__)
+  File.write whats_new.to_s, renderer.result(binding)
 end

--- a/lib/tasks/versions.rake
+++ b/lib/tasks/versions.rake
@@ -4,3 +4,15 @@ desc "Print the Bundler versions the site documents"
 task :versions do
   puts VERSIONS.join(' ')
 end
+
+namespace :versions do
+  desc "Prepare a new version"
+  task :create do
+    last = VERSIONS.last
+    succ = VERSIONS.last.succ
+    puts "Latest version is #{last}. Creating version #{succ}..."
+    cp_r "source/#{last}", "source/#{succ}"
+    cp_r "source/localizable/#{last}", "source/localizable/#{succ}"
+    sh "middleman article 'Bundler #{succ}'"
+  end
+end

--- a/lib/templates/whats_new.html.haml.erb
+++ b/lib/templates/whats_new.html.haml.erb
@@ -1,0 +1,23 @@
+.container.guide
+  = partial "shared/whats_new"
+
+  %p
+    The
+    = link_to 'Bundler <%= version %> announcement', '/blog/<%= date_slug %>/bundler-<%= version_slug %>.html'
+    includes context and a more detailed explanation of the changes in this version. This is a summary of the biggest changes. As always, a detailed list of every change is provided in
+    == #{link_to "the changelog", "https://github.com/bundler/bundler/blob/<%= version_slug %>-stable/CHANGELOG.md"}.
+
+  %h3 BIG NEW THING
+  .contents
+    .bullet
+      .description
+        %p
+          THE BIG NEW THING DOES COOL NEW STUFF.
+
+  .contents
+    .bullet
+      .description
+      Bundler <%= version %> also includes:
+      %ul
+        %li SMALL NEW THING FIXES A PROBLEM
+      = link_to 'Full <%= version %> changelog', 'https://github.com/bundler/bundler/blob/<%= version_slug %>-stable/CHANGELOG.md', class: 'btn btn-primary'

--- a/source/blog/2017-05-19-bundler-1-15-bundle-oh-so-fast.html.markdown
+++ b/source/blog/2017-05-19-bundler-1-15-bundle-oh-so-fast.html.markdown
@@ -23,7 +23,7 @@ Finally, we've managed to avoid evaluating the full `.gemspec` of all the gems t
 
 ### New Commands
 
-We've added 3 new commands that have been on our wish list for a long time.
+We've added 4 new commands that have been on our wish list for a long time.
 
 #### `bundle info`
 

--- a/source/v1.14/whats_new.html.haml
+++ b/source/v1.14/whats_new.html.haml
@@ -38,7 +38,7 @@
   .contents
     .bullet
       .description
-      Bundler 1.13 also includes:
+      Bundler 1.14 also includes:
       %ul
         %li Installing gems using `sudo` will now always prompt for a password, even if the sudo password is cached from an earlier command
         %li The Gemfile method `platform` now supports Ruby 2.5, allowing arguments like `:ruby_25` or `:mri_25`.

--- a/source/v1.15/whats_new.html.haml
+++ b/source/v1.15/whats_new.html.haml
@@ -6,3 +6,31 @@
     = link_to 'Bundler 1.15 announcement', '/blog/2017/05/19/bundler-1-15-bundle-oh-so-fast.html'
     includes context and a more detailed explanation of the changes in this version. This is a summary of the biggest changes. As always, a detailed list of every change is provided in
     == #{link_to "the changelog", "https://github.com/bundler/bundler/blob/1-15-stable/CHANGELOG.md"}.
+
+  %h3 Exec optimization
+  .contents
+    .bullet
+      .description
+        %p
+          We've made `bundle exec` faster by reducing the impact of each additional gem in your application. In applications with hundreds of gems, this change made `exec` half a second (!) faster.
+
+  %h3 `bundle issue`
+  .contents
+    .bullet
+      .description
+        %p
+          The `issue` command provides troubleshooting help. If the problem persists, this command will help you open an issue in the Bundler issue tracker with all of the information that we need to help.
+
+  %h3 `bundle add`
+  .contents
+    .bullet
+      .description
+        %p
+          Finally, you can add gems to your Gemfile directly from the command line, without having to edit your Gemfile first. We've got plans to make this command even better, but this is a good start.
+
+  %h3 `bundle pristine`
+  .contents
+    .bullet
+      .description
+        %p
+          Just like the `gem pristine` command, the `bundle pristine` command wipes out any changes you have made to the gems installed locally, for testing or debugging reasons, and restores them to a freshly-installed state.


### PR DESCRIPTION
The localized sources were missed for version 1.15, leading to 404s on guides. It seems good to create a task that makes sure guides will be available for new versions. 👍 