### PR TITLE
[wip] RubyGems.org SSL troubleshooting guide

### DIFF
--- a/source/localizable/v1.15/guides/how_bundler_uses_ssl.en.html.md
+++ b/source/localizable/v1.15/guides/how_bundler_uses_ssl.en.html.md
@@ -1,0 +1,24 @@
+# How Bundler uses SSL certificates
+
+## Introduction
+
+All web browsers come with a certificate authority (CA) bundle. These are cryptographic certificates provided by the companies that sell SSL certificates (like Verisign, Globalsign, and others). Using those "root” keys/certificates (they’re called root keys because they are the keys from which many other companies and websites derive their SSL certificates), web browsers “know” they can trust the SSL certificate being given to them by a particular website, such as RubyGems.org.
+ 
+Occasionally, new companies are added to the CA bundle, or existing companies have their certificates expire and need to distribute new ones. For most websites, this isn't a huge problem, because web browsers regularly update their CA bundle as part of general browser updates. 
+ 
+## How Ruby uses CA bundles
+
+The SSL certificate used by RubyGems.org descends from a new-ish root certificate. Ruby (and therefore RubyGems and Bundler) does not have a regularly updated CA bundle to use when contacting websites. Usually, Ruby uses a CA bundle provided by the operating system (OS). On older OSes, this CA bundle can be really old—as in a decade old. Since a CA bundle that old can’t verify the (new-ish) certificate for RubyGems.org, you might see the error in question: `certificate verify failed`.
+ 
+Further complicating things, an otherwise unrelated change 18-24 months ago lead to a new SSL certificate being issued for RubyGems.org. This meant the “root” certificate that needed to verify connections changed. So even if you’d previously upgraded RubyGems/Bundler in order to fix the SSL problem, you would need to upgrade again—this time to an even newer version with even newer certificates.
+ 
+## Fixing SSL certificate errors
+
+There are two ways to supply the certificate Ruby needs to verify RubyGems.org:
+ 
+1. Update to the latest versions of RubyGems/Bundler, which include the relevant certificates in the gem and ask Ruby to use them, or
+2. You can update the certificates provided by your OS. This lets Ruby use those certificates to successfully verify the connection.
+
+You can upgrade Bundler by running `gem install bundler`, and you can upgrade RubyGems by running `gem update --system`. If you're still having trouble even after running those commands, check out our [SSL Troubleshooting Guide][1] for more help.
+
+[1]: ssl_troubleshooting.html

--- a/source/v1.15/docs.html.haml
+++ b/source/v1.15/docs.html.haml
@@ -18,6 +18,7 @@
         %li= link_to 'Installing gems from git repos', "/#{current_visible_version}/git.html"
         %li= link_to 'Setting up & using bundled gems', "/#{current_visible_version}/bundler_setup.html"
         %li= link_to 'Developing a RubyGem using Bundler', "/#{current_visible_version}/guides/creating_gem.html"
+        %li= link_to 'How Bundler uses SSL', "/#{current_visible_version}/guides/how_bundler_uses_ssl.html"
         %li= link_to 'Deploying', "/#{current_visible_version}/deploying.html"
         %li= link_to 'Sharing', "/#{current_visible_version}/bundler_sharing.html"
         %li= link_to 'Updating Gems', "/#{current_visible_version}/updating_gems.html"


### PR DESCRIPTION
This guide is a work in progress. Please don't merge it yet.

### What was the end-user problem that led to this PR?

Today, users of Bundler and RubyGems can run into SSL errors if their system CA cert bundle is old, or if they are running an older version of Bundler/RubyGems. By January 2018, users will start to see errors if their Ruby is linked against Openssl < 1.0.1, because that is when we will start to require TLSv1.2.

### Was was your diagnosis of the problem?

After consultation with @rubymorillo, our diagnosis was that the existing RubyGems SSL guide is both a confusing patchwork of different writeups and also out of date.

### What is your fix for the problem, implemented in this PR?

Our fix is to write comprehensive Bundler/RubyGems guide(s), explaining why we use SSL in the first place, what the underlying cause of the various SSL errors is, and suggestions for how to possibly fix those errors, as well as links to other potential resources.

### Why did you choose this fix out of the possible options?

Writing better docs and being able to refer to them sounds wayyyy better than trying to help out users with the same problems one at a time.