### PR TITLE
remove livereload

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ ruby File.read(File.expand_path('../.ruby-version', __FILE__)).strip
 
 gem 'octokit', '~> 4.3'
 gem 'middleman', '~> 4.2'
-gem 'middleman-livereload'
 gem 'middleman-syntax'
 gem 'middleman-blog'
 gem 'middleman-compass'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,13 +36,9 @@ GEM
     concurrent-ruby (1.0.5)
     contracts (0.13.0)
     dotenv (2.2.1)
-    em-websocket (0.5.1)
-      eventmachine (>= 0.12.9)
-      http_parser.rb (~> 0.6.0)
     erubis (2.7.0)
     ethon (0.9.0)
       ffi (>= 1.3.0)
-    eventmachine (1.2.0.1)
     execjs (2.7.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
@@ -66,7 +62,6 @@ GEM
     highline (1.7.8)
     hpricot (0.8.6)
     htmlcompressor (0.2.0)
-    http_parser.rb (0.6.0)
     i18n (0.7.0)
     jquery-middleman (3.1.2)
       thor (>= 0.14, < 2.0)
@@ -120,10 +115,6 @@ GEM
       servolux
       tilt (~> 2.0)
       uglifier (~> 3.0)
-    middleman-livereload (3.4.6)
-      em-websocket (~> 0.5.1)
-      middleman-core (>= 3.3)
-      rack-livereload (~> 0.3.15)
     middleman-minify-html (3.4.1)
       htmlcompressor (~> 0.2.0)
       middleman-core (>= 3.2)
@@ -167,8 +158,6 @@ GEM
       json
       websocket (~> 1.0)
     rack (2.0.3)
-    rack-livereload (0.3.16)
-      rack
     rake (12.0.0)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.10)
@@ -224,7 +213,6 @@ DEPENDENCIES
   middleman (~> 4.2)
   middleman-blog
   middleman-compass
-  middleman-livereload
   middleman-minify-html
   middleman-search
   middleman-sprockets (~> 4.0)

--- a/config.rb
+++ b/config.rb
@@ -118,10 +118,6 @@ end
 
 page "/blog/feed.xml", layout: false
 
-configure :development do
-  activate :livereload
-end
-
 configure :build do
   activate :minify_css
   activate :minify_javascript


### PR DESCRIPTION
it is apparently unmaintained, and because it triggers a full reload for
every single html file anytime any html file is changed, our site causes
it to get stuck livereloading every single file D: