### PR TITLE
prefix `/` to guides URL to force an abolsute path

### DIFF
--- a/helpers/guides_helper.rb
+++ b/helpers/guides_helper.rb
@@ -34,8 +34,8 @@ module GuidesHelper
 
   def process_localizable(filename)
     matched = filename.match(LOCALIZABLE_REGEX)
-    return filename unless matched
+    return "/#{filename}" unless matched
 
-    "#{matched[1]}.html"
+    "/#{matched[1]}.html"
   end
 end


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Selecting a guide in the sidebar whilst currently reading another guide would result in a page not found. Closes #314.

### Was was your diagnosis of the problem?

This issue appears to be have been introduced in https://github.com/bundler/bundler-site/commit/5f1163c9ea2b98fe37dbd15aac989173ba77c38b where middleman was updated to a newer release.

In the guides helper, it's generating the paths to guides like `v1.15/guides/using_bundler_in_applications`. This used to have been made into an absolute path by Middleman but this no longer appears to be the case.

### What is your fix for the problem, implemented in this PR?

Prefix the guide URLs with a forward slash to force an absolute path instead of being relative