### PR TITLE
remove excess padding in code/command examples

### DIFF
--- a/source/v1.15/bundler_setup.html.haml
+++ b/source/v1.15/bundler_setup.html.haml
@@ -71,7 +71,6 @@
       :code
         # lang: ruby
         Bundler.require(:default)
-
       For our example Gemfile, this line is exactly equivalent to:
 
       :code
@@ -79,7 +78,6 @@
         require 'rails'
         require 'rack-cache'
         require 'nokogiri'
-
     .bullet
       .description
         Astute readers will notice that the correct way to require the <code>rack-cache</code>
@@ -93,7 +91,6 @@
         gem 'rails', '5.0.0'
         gem 'rack-cache', :require => 'rack/cache'
         gem 'nokogiri', '~> 1.4.2'
-
     .bullet
       .description
         For such a small <code>Gemfile</code>, we'd advise you to skip

--- a/source/v1.15/faq.html.haml
+++ b/source/v1.15/faq.html.haml
@@ -134,7 +134,6 @@
 
         :code
           $ bundle config build.mysql --with-mysql-config=/usr/local/mysql/bin/mysql_config
-
         %p
           Bundler will store this configuration in <code>~/.bundle/config</code>, and bundler will use
           the configuration for any <code>bundle install</code> performed by the same user. As a result, once
@@ -153,7 +152,6 @@
 
         :code
           $ bundle install --local
-
         %h3
           Bundling From RubyGems is Really Slow
 

--- a/source/v1.15/gemfile.html.haml
+++ b/source/v1.15/gemfile.html.haml
@@ -149,7 +149,6 @@
       :code
         # lang: ruby
         ruby '1.9.3'
-
     .bullet
       .description
         What this means is that this app has a dependency to a Ruby VM that is ABI compatible with 1.9.3. If the version check does not match, Bundler will raise an exception. This will ensure the running code matches. You can be more specific with the <code>:engine</code> and <code>:engine_version</code> options.

--- a/source/v1.15/groups.html.haml
+++ b/source/v1.15/groups.html.haml
@@ -26,7 +26,6 @@
         end
 
         gem 'cucumber', :group => [:cucumber, :test]
-
     .bullet
       .description
         Install all gems, except those in the
@@ -34,7 +33,6 @@
         non-excluded group will still be installed.
       :code
         $ bundle install --without test development
-
     .bullet
       .description
         Require the gems in particular groups,
@@ -43,7 +41,6 @@
       :code
         # lang: ruby
         Bundler.require(:default, :development)
-
     .bullet
       .description
         Require the default gems, plus the gems
@@ -52,7 +49,6 @@
       :code
         # lang: ruby
         Bundler.require(:default, Rails.env)
-
     .bullet
       .description
         Restrict the groups of gems that you
@@ -92,14 +88,12 @@
         group :production do
           gem 'pg'
         end
-
     .bullet
       .description
         Now, in development, you can instruct bundler to skip the <code>production</code> group:
 
       :code
         $ bundle install --without production
-
     .bullet
       .description
         Bundler will remember that you installed the gems using <code>--without

--- a/source/v1.15/rails.html.haml
+++ b/source/v1.15/rails.html.haml
@@ -23,14 +23,12 @@
       :code
         $ rails new myapp
         $ cd myapp
-
     .bullet
       .description
         Run the server. Bundler is transparently managing
         your dependencies!
       :code
         $ rails server
-
     .bullet
       .description
         Add new dependencies to your Gemfile as you
@@ -39,7 +37,6 @@
         # lang: ruby
         gem 'nokogiri'
         gem 'geokit'
-
     .bullet
       .description
         If you want a dependency to be loaded only in
@@ -51,7 +48,6 @@
           gem 'rspec'
           gem 'faker'
         end
-
     .bullet#shared_with_23
       .description
         You can place a dependency in multiple groups

--- a/source/v1.15/rubygems.html.haml
+++ b/source/v1.15/rubygems.html.haml
@@ -10,7 +10,6 @@
           $ bundle gem my_gem
         .notes
           This will create a new directory named <code>my_gem</code> with your new gem skeleton.
-
     .bullet
       .description
         If you already have a gem with a gemspec, you can generate a Gemfile for your gem.
@@ -21,21 +20,18 @@
       :code
         # lang: ruby
         gemspec
-
     .bullet
       .description
         Runtime dependencies in your gemspec are treated like base dependencies, and development dependencies are added by default to the group, <code>:development</code>. You can change that group with the <code>:development_group</code> option
       :code
         # lang: ruby
         gemspec :development_group => :dev
-
     .bullet
       .description
         As well, you can point to a specific gemspec using <code>:path</code>. If your gemspec is in <code>/gemspec/path</code>, use
       :code
         # lang: ruby
         gemspec :path => '/gemspec/path'
-
     .bullet
       .description
         If you have multiple gemspecs in the same directory, specify which one you'd like to reference using <code>:name</code>

--- a/source/v1.15/updating_gems.html.haml
+++ b/source/v1.15/updating_gems.html.haml
@@ -48,7 +48,6 @@
 
       :code
         $ bundle install
-
       %p.description
         As described above, the <code>bundle install</code> command always does a conservative
         update, refusing to update gems (or their dependencies) that you have not explicitly
@@ -90,7 +89,6 @@
 
         :code
           $ bundle update rack-cache
-
         %p
           This command will update <code>rack-cache</code> and its dependencies to the latest
           version allowed by the <code>Gemfile</code> (in this case, the latest version
@@ -108,7 +106,6 @@
 
         :code
           $ bundle update
-
         %p
           This will resolve dependencies from scratch, ignoring the <code>Gemfile.lock</code>. If
           you do this, keep <code>git reset --hard</code> and your test suite in your back pocket.


### PR DESCRIPTION
This PR is just removing the extra padding at the bottom of code examples that still have them