### PR TITLE
Add git bisect explanation to "How to git bisect in projects using Bundler" guide

### DIFF
--- a/source/v1.14/git_bisect.html.md
+++ b/source/v1.14/git_bisect.html.md
@@ -2,6 +2,12 @@
 title: How to git bisect in projects using Bundler
 ---
 
+## How to use git bisect
+
+[`git bisect`](https://git-scm.com/docs/git-bisect) is a useful debugging tool. For context, `git bisect` is a git command that can be used to track down the specific commit which a bug was introduced into the codebase.
+
+If you can find a commit where the code works properly and a commit with the offending bug, you don’t have to trace down the buggy commit by hand. The `git bisect` command, via binary search, will help you find the offending commit. For example, the Git documentation has [a handy `git bisect` guide](https://git-scm.com/book/en/v2/Git-Tools-Debugging-with-Git) that shows two ways to use it.
+
 ## How to git bisect in projects using Bundler
 
 A few things that may not be obvious are needed for `git bisect` to work


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was...
- I saw there was no background explanation of the `git bisect`command in the "How to `git bisect` in projects using Bundler" docs guide.

### Was was your diagnosis of the problem?

My diagnosis was...
- I added a new section at the beginning of the "How to `git bisect` in projects using Bundler" guide background information about what `git bisect` does.

### What is your fix for the problem, implemented in this PR?

My fix...
- I wrote up an introductory explanation of `git bisect`, and linked to the official git documentation, as well as to a Thoughtbot blog post that guides the user on how exactly to use `git bisect` with examples.

### Why did you choose this fix out of the possible options?

I chose this fix because...
- I thought this guide in particular would be less intimidating to anyone who is not familiar with the `git bisect` command if they are given some background explanation. 🍒

- Please let me know if you think this background explanation shouldn't go in its own section, and if it should rather be interspersed throughout the guide.
Happy to incorporate any changes!