### PR TITLE
Fixing guides helper and guides url helper

### DIFF
--- a/helpers/guides_helper.rb
+++ b/helpers/guides_helper.rb
@@ -6,18 +6,20 @@ module GuidesHelper
     guides = Dir.glob("./source/#{current_visible_version}/guides/*")
     localizable_guides = Dir.glob("./source/localizable/#{current_visible_version}/guides/*.en.html.md")
     all_guides = guides + localizable_guides + ADDITIONAL_GUIDES
-    all_guides.map! { |md_file| md_file.sub(/^\.\/source\//, '').sub(/\.(md|haml)$/, '') }
 
-    all_guides.map do |filename|
+    guides = all_guides.map do |filename|
+      filename = filename.sub(/^\.\/source\//, '').sub(/\.(md|haml)$/, '')
       resource = sitemap.find_resource_by_path(filename)
       next unless resource
       { filename: filename, title: resource.metadata[:page][:title] }
-    end.select { |page| page[:title] }.sort_by { |page| page[:title] }
+    end.compact
+
+    guides.select { |page| page[:title] }.sort_by { |page| page[:title] }
   end
 
   def link_to_guide(page, options = {})
     filename = process_localizable(page[:filename])
-    link_to page[:title], '/' + filename, options
+    link_to page[:title], filename, options
   end
 
   def current_guide?(filename)


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

Currently the guides are not being linked correctly in the sidebar and the `guides` helper is breaking in development due calling a method on `nil`

### Was was your diagnosis of the problem?

Clicking any link to the a guide in the sidebar does not go the intended page. And going to `docs.html` would break in development.

### What is your fix for the problem, implemented in this PR?

Remove `nil`s in the guides helper and remove the extra `/` in the guides url helper.
