### PR TITLE
Get rid of unnecessary extra spacing on What's New in each Release page

### DIFF
--- a/source/stylesheets/application.css.scss
+++ b/source/stylesheets/application.css.scss
@@ -59,6 +59,10 @@ $navbar-height: 50px;
   margin-right: auto;
 }
 
+.row:after {
+  clear: none;
+}
+
 .bg-light-blue {
   background-color: #DBEAF3;
   padding: 30px 2%;


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was...
I came across this extra space on [What's New in each Release for v1.15](http://bundler.io/v1.15/whats_new.html)
![screen shot 2017-08-10 at 7 49 50 pm](https://user-images.githubusercontent.com/15078895/29200714-5a98da6e-7e0c-11e7-88ad-f1a1afb48ee5.png)




### Was was your diagnosis of the problem?

My diagnosis was...
- I think there was some problem with Bootstrap styles.
### What is your fix for the problem, implemented in this PR?

My fix...
- The pseudo `:after` element on the `.row` class caught my eye. I tinkered around, wrote over a default Boostrap style, and came up with this fix.
- Now, it should hopefully look like this:
![screen shot 2017-08-10 at 9 28 56 pm](https://user-images.githubusercontent.com/15078895/29201428-05f74660-7e13-11e7-97f0-bd02ce1e4a3a.png)

### Why did you choose this fix out of the possible options?

I chose this fix because...
- It's a quick fix to solve the spacing issue 
- Closes #325 