### PR TITLE
Remove duplicate header in What's New post

### DIFF
--- a/source/v1.12/whats_new.html.haml
+++ b/source/v1.12/whats_new.html.haml
@@ -1,9 +1,5 @@
 -# TODO maybe add header?
 
----
-title: What's New in v1.12
----
-
 .container.guide
   = partial "shared/whats_new"
 
@@ -44,4 +40,3 @@ title: What's New in v1.12
           %li support for frozen string literals
           %li many, many, many bugfixes
         = link_to 'Full 1.12 changelog', 'https://github.com/bundler/bundler/blob/1-12-stable/CHANGELOG.md', class: 'btn btn-primary'
-


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was...
- There was a duplicate header for Bundler's "What's New in Each Release" v1.12 update. 

### Was was your diagnosis of the problem?

My diagnosis was...
- To get rid of it

### What is your fix for the problem, implemented in this PR?

My fix...
- Delete the unnecessary header.

### Why did you choose this fix out of the possible options?

I chose this fix because...
- Resolves Issue #326 