### PR TITLE
Fix broken link in 'What's New in v1.12'

### DIFF
--- a/source/v1.12/whats_new.html.haml
+++ b/source/v1.12/whats_new.html.haml
@@ -15,15 +15,14 @@ title: What's New in v1.12
     .bullet
       .description
         %p
-          Bundler now fetches gem metadata using [the new index format](http://andre.arko.net/2014/03/28/the-new-rubygems-index-format/), speeding up `install` significantly. In addition to the speed increases provided by the format itself, we’re also serving the new index directly from the Fastly CDN. That means Bundler will be able to talk to a server located nearby, no matter where you are in the world. We expect that to make a huge difference, especially in Oceania and Africa. 🎉
-
+          Bundler now fetches gem metadata using <a href="http://andre.arko.net/2014/03/28/the-new-rubygems-index-format/" target="_blank">the new index format</a> speeding up <code>install</code> significantly. In addition to the speed increases provided by the format itself, we’re also serving the new index directly from the Fastly CDN. That means Bundler will be able to talk to a server located nearby, no matter where you are in the world. We expect that to make a huge difference, especially in Oceania and Africa. 🎉
   %h3 Outdated by version significance
 
   .contents
     .bullet
       .description
         %p
-          It is now possible to run `bundle outdated` with the flags `--major`, `--minor`, and `--patch`. Using those flags, you can limit Bundler to only show you new versions that are both allowed by your `Gemfile` and also meet the criteria of only changing the major, minor, or patch version of the gem. You can combine them to get only minor and patch updates, or even only major and patch updates (but I have no idea why you would want to do that)
+          It is now possible to run <code>bundle outdated</code> with the flags <code>--major</code>, <code>--minor</code>, and <code>--patch</code>. Using those flags, you can limit Bundler to only show you new versions that are both allowed by your <code>Gemfile</code> and also meet the criteria of only changing the major, minor, or patch version of the gem. You can combine them to get only minor and patch updates, or even only major and patch updates (but I have no idea why you would want to do that)
 
   %h3 Ruby version locking
 
@@ -44,4 +43,3 @@ title: What's New in v1.12
           %li support for frozen string literals
           %li many, many, many bugfixes
         = link_to 'Full 1.12 changelog', 'https://github.com/bundler/bundler/blob/1-12-stable/CHANGELOG.md', class: 'btn btn-primary'
-


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was...
- While reading through the "What's New in V1.12" of Bundler blog post, I noticed there was a broken link and some missing markup. 
It looked like this:
![screen shot 2017-08-27 at 7 39 57 pm](https://user-images.githubusercontent.com/15078895/29757837-c67ec84c-8b63-11e7-9cc6-d7efd6507724.png)


### Was was your diagnosis of the problem?

My diagnosis was...
- I guess markdown syntax doesn't work in the `haml` blog post files. 

### What is your fix for the problem, implemented in this PR?

My fix...
- I added in vanilla HTML into the `haml` blog post file to add in the markup and fix the broken link.
- It should look like this, now:
![screen shot 2017-08-27 at 7 39 09 pm](https://user-images.githubusercontent.com/15078895/29757874-00b2d38c-8b64-11e7-8d6c-9499ab279841.png)


### Why did you choose this fix out of the possible options?

I chose this fix because...
- to improve the user's experience on the bundler.io site ✨