### PR TITLE
Add quality spec for bundler.io docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
   - bundle install --deployment
   - eval "$(ssh-agent -s)"
 script:
+  - ruby spec/quality_spec.rb
   - |
       if [ "$TRAVIS_BRANCH" = "master" ];
       then bundle exec rake travis:deploy

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'nokogiri', '~> 1.7'
 gem 'haml', '~> 4.0.7'
 
 group :development do
+  gem 'colorize'
   gem 'pry'
   gem 'pry-byebug'
   gem 'travis'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
+    colorize (0.8.1)
     compass (1.0.3)
       chunky_png (~> 1.2)
       compass-core (~> 1.0.2)
@@ -207,6 +208,7 @@ PLATFORMS
 DEPENDENCIES
   bootstrap-sass
   builder
+  colorize
   haml (~> 4.0.7)
   jquery-middleman
   kramdown
@@ -230,4 +232,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.15.1
+   1.15.4

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -1,0 +1,42 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'colorize'
+require 'pathname'
+require 'time'
+
+errors = []
+
+def matches(pattern, message)
+  pattern = /\b#{Regexp.union(pattern)}\b/ if pattern.is_a?(Array)
+  matches = []
+  files = Pathname.glob(File.expand_path("../source/**/*.{html,md,markdown,erb,haml}*", __dir__))
+
+  files.each do |file|
+    next unless file.file?
+    relative_path = file.relative_path_from(Pathname('..').expand_path(__dir__))
+
+    skippable_directories = %w[source/man source/localizable source/layouts]
+
+    next if relative_path.to_s =~ Regexp.union(skippable_directories)
+    next if relative_path.to_s =~ %r{\Asource/v([\d.]+)} && Gem::Version.new($1) <= Gem::Version.new("1.15")
+    # this hackily skips blog posts touched before September 17th, 2017:
+    next if File.mtime(relative_path.to_s) < Time.parse("2017-09-17")
+
+    File.readlines(file).each_with_index do |line, index|
+      next unless line =~ pattern
+
+      matches << "`#{relative_path}:#{index.succ}` #{message}"
+    end
+  end
+  matches
+end
+
+errors.concat matches(%w[he she her his], "Don't use gendered pronouns")
+errors.concat matches(%w[actually really just only], "Don't use superflous language")
+
+if errors.empty?
+  puts 'Specs passed'.colorize(:green)
+else
+  abort "The docs need some attention:\n\t- #{errors.join("\n\t- ")}".colorize(:red)
+end


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was...
- Except for the man page documentation, there are no specs that test the quality of documentation on the [bundler.io](https://bundler.io) site. 

### What was your diagnosis of the problem?

My diagnosis was...
- I added a quality spec that includes checking the quality of the blog posts and blog updates. Most notably, it sifts out gendered language as well as _actually_'s and other similar language so that we don't accidentally disrespect our reader. 

### What is your fix for the problem, implemented in this PR?

My fix...
- Create a script spec that sifts out unnecessary and non-inclusive language in the bundler documentation site's blogposts and guides. 
### Why did you choose this fix out of the possible options?

I chose this fix because...
- I spent a while trying to research ways to setup and incorporate RSpec into the [bundler.io](https://bundler.io) site but documentation related to trying to set-up RSpec with Middleman was kind of lacking. Plus, it doesn't seem like many people use RSpec with Middleman to begin with. This is a light-weight alternative.