### PR TITLE
Fix link for the current getting started guide

### DIFF
--- a/source/localizable/index.html.haml
+++ b/source/localizable/index.html.haml
@@ -14,7 +14,7 @@
 
       %p.text-center
         = link_to "What's new?", '/whats_new.html', class: 'btn btn-primary btn-lg btn-responsive'
-        = link_to t('home.how_bundler_work_button'), '/v1.12#getting-started', class: 'btn btn-primary btn-lg btn-responsive'
+        = link_to t('home.how_bundler_work_button'), "./#{current_version}/#getting-started", class: 'btn btn-primary btn-lg btn-responsive'
 
 .row.bg-light-blue
   .container


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

In the homepage the `How Does Bundler Work?` link is pointing to the getting started guide from `v1.12` instead of using the current version.

### What is your fix for the problem, implemented in this PR?

This commit fixes this and it also replaces the hardcoded version number with the `current_version`, so in the future, we don't have to update it manually.