### PR TITLE
Fix broken links for index page in v1.15

### DIFF
--- a/source/v1.15/index.html.haml
+++ b/source/v1.15/index.html.haml
@@ -19,7 +19,10 @@
 .contents
   .bullet
     .description
-      %p This guide assumes that you have both [Ruby](https://www.ruby-lang.org/en/downloads/) and [RubyGems](https://rubygems.org/pages/download) installed. If you do not have Ruby and RubyGems installed, do that first and then check back here!
+      %p
+        This guide assumes that you have both #{ link_to("Ruby", "https://www.ruby-lang.org/en/downloads/") }
+        and #{ link_to("RubyGems", "https://rubygems.org/pages/download") } installed. If you do not have Ruby
+        and RubyGems installed, do that first and then check back here!
   .bullet
     .description
       %p
@@ -63,7 +66,7 @@
 
       # require your gems as usual
       require 'nokogiri'
-    = link_to 'Learn More: Bundler.setup', './bundler_setup.html', class: 'btn btn-primary'
+    = link_to 'Learn More: Bundler.setup', './guides/bundler_setup.html', class: 'btn btn-primary'
   .bullet
     .description
       %p


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

In the index page, there is a broken link and also two markdown style links which do not render those link properly.

### What is your fix for the problem, implemented in this PR?

This commit changes those to `haml` link helper and it also fixes the bundler setup guides path, which was changed in `v1.15`.