### PR TITLE
Fix broken links in the doc index page

### DIFF
--- a/source/v1.15/index.html.haml
+++ b/source/v1.15/index.html.haml
@@ -128,8 +128,8 @@
 %h2#use-bundler Use Bundler with
 .contents
   .buttons
-    = link_to 'Rails', './rails.html', class: 'btn btn-primary'
-    = link_to 'Sinatra', './sinatra.html', class: 'btn btn-primary'
+    = link_to 'Rails', './guides/rails.html', class: 'btn btn-primary'
+    = link_to 'Sinatra', './guides/sinatra.html', class: 'btn btn-primary'
     = link_to 'RubyGems', './rubygems.html', class: 'btn btn-primary'
     = link_to 'RubyMotion', './rubymotion.html', class: 'btn btn-primary'
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

In the `/v1.15` page, we have a section called `Use Bundler with`, where we have some links that were intended to point to the guides. But unfortunately, those links are broken and still seems to point to the old html file that does not exist anymore

### What is your fix for the problem, implemented in this PR?

This commit fixes those links and points those broken link to the correct guide path that changed in PR #322.