### PR TITLE
Minor updates on the deploying guide

### DIFF
--- a/source/v1.15/guides/deploying.html.haml
+++ b/source/v1.15/guides/deploying.html.haml
@@ -79,14 +79,14 @@ title: Deploying with Bundler
         Alternatively, you can use the <code>--binstubs</code> option on the
         install command to generate executable binaries that can be used instead of
         <code>bundle exec</code>.
-      = link_to 'Learn More: Executables', './man/bundle-exec.1.html', class: 'btn btn-primary'
+      = link_to 'Learn More: Executables', '/man/bundle-exec.1.html', class: 'btn btn-primary'
 
     .bullet
       .description
         %h3 Heroku
         When you deploy to Heroku, Bundler will be run automatically as long as a Gemfile is present. If you check in your Gemfile.lock, Heroku will run <code>`bundle install --deployment`</code>. If you want to exclude certain groups using the <code>--without</code> option, you need to use <code>`heroku config`</code>.
       :code
-        $ heroku config:add BUNDLE_WITHOUT="test development" --app app_name
+        $ heroku config:set BUNDLE_WITHOUT="test development" --app app_name
       = link_to 'Heroku Bundler Documentation', 'http://docs.heroku.com/bundler', class: 'btn btn-primary'
 
     %h2#deploying-your-application


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

In the `Deploying bundled applications` (Link: `/guides/deploying.html`) guide, there seems to be a broken link, the `executables` does not seems to be linking to the correct path. And, the guide also using a sample from the old Heroku's way of adding the configuration.

### What is your fix for the problem, implemented in this PR?

This commit fixes that link to the correct path, and it also updates the Heroku sample to their latest way of configuring environment variable.

Ref: https://devcenter.heroku.com/articles/bundler