### PR TITLE
Enable missing pages to be searchable

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -7,7 +7,7 @@ activate :syntax
 activate :i18n
 activate :sprockets
 activate :search do |search|
-  search.resources = ['index.html', "#{config[:current_version]}/", '/doc/contributing/issues.html']
+  search.resources = ['index.html', "#{config[:current_version]}/", 'compatibility.html', 'conduct.html', 'contributors.html', 'older_versions.html']
 
   search.index_path = 'search/lunr-index.json'
 

--- a/source/compatibility.html.haml
+++ b/source/compatibility.html.haml
@@ -1,3 +1,8 @@
+---
+title: Bundler compatibility with Ruby
+description: Ruby and RubyGems requirements needed for Bundler compatibility
+---
+
 %h2 Bundler compatibility with Ruby
 
 .contents

--- a/source/conduct.html.md
+++ b/source/conduct.html.md
@@ -1,3 +1,8 @@
+---
+title: Code of conduct
+description: Rules to adhere to while contributing to Bundler
+---
+
 # Bundler Code of Conduct
 
 The Bundler project strongly values contributors from anywhere, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, ethnicity, age, religion, or nationality. As a result, the Bundler team has agreed to and enforces this code of conduct in order to provide a harassment-free experience for everyone who participates in the development of Bundler.

--- a/source/contributors.html.haml
+++ b/source/contributors.html.haml
@@ -1,3 +1,7 @@
+---
+title: Contributors
+---
+
 .row.bg-light-blue.header
   = image_tag '/images/team_header_transparent_bg.png',
     srcset: '/images/team_header_transparent_bg.png 1x, /images/team_header_transparent_bg@2x.png 2x, /images/team_header_transparent_bg@3x.png 3x',

--- a/source/older_versions.html.haml
+++ b/source/older_versions.html.haml
@@ -1,8 +1,9 @@
+---
+title: Older Versions of Bundler
+---
 .container
   %h2 Older Versions of Bundler
   .row
     .col-sm-12.text-center
       - versions.reverse.select{ |version| path_exist?('docs', version) || path_exist?('index', version) }.each do |v|
         = link_to v, "/#{v}/#{path_exist?('docs', v) ? 'docs' : 'index'}.html", class: "btn btn-sm #{current_visible_version == v ? 'btn-default' : 'btn-primary'}"
-
-

--- a/source/sponsors.html.haml
+++ b/source/sponsors.html.haml
@@ -1,3 +1,8 @@
+---
+title: Sponsors
+description: Companies who sponsor Bundler and RubyTogether
+---
+
 %h2 Bundler Project Sponsors
 
 %p Development work on Bundler has been sponsored by many companies over the years. Here, we thank the companies that have directly contributed money or significant paid time to implement features or fix bugs.

--- a/source/stylesheets/_search.scss
+++ b/source/stylesheets/_search.scss
@@ -49,7 +49,7 @@
 .search-list-ul {
   list-style-type: none;
   padding-left: 0;
-
+  
   hr {
     margin-top: 0;
     margin-bottom: 0;


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was...
- Like @lynncyrin noted in Issue #254, not all pages come up in Bundler.io's search. 
### What was your diagnosis of the problem?

My diagnosis was...
Specifically, the missing pages that should be searchable but currently weren't include:
- `compatibility.html`
- `conduct.html`
- `contributors.html`
- `older_versions.html`

### What is your fix for the problem, implemented in this PR?

My fix...
- I read through [the documentation for the Middleman search gem](https://github.com/manastech/middleman-search) that bundler.io uses and found out that in order to make a page searchable, we need to both give the page [frontmatter](https://middlemanapp.com/basics/frontmatter/) (the YAML at the top of the page), and append it to the `search.resources` array in `config.rb`. 
- I also deleted `'/doc/contributing/issues.html'` from the `search.resources` array since that page no long exists.
- I also added some CSS to give the search-box result elements a max-width. Otherwise, the width of these elements would be much wider than the search box itself if the page's description was long.
- To illustrate, this is what it would look like without giving the search box element a max-width:
- ![screen shot 2017-10-15 at 6 23 38 pm](https://user-images.githubusercontent.com/15078895/31591885-da9678c0-b1d8-11e7-9393-1e8faea9fca4.png)
- This is what it looks like with a max-width:
- ![screen shot 2017-10-15 at 6 22 35 pm](https://user-images.githubusercontent.com/15078895/31591891-f39e3448-b1d8-11e7-9258-1324f169ee2d.png)


### Why did you choose this fix out of the possible options?
I chose this fix because...
- I think it's important for bundler users to be able to search for all bundler documentation pages.
- I think the CSS change will prevent search-results from looking too big. This will make the CSS more maintainable in the long-run. ✨