### PR TITLE
Fix a broken link in the using group guide

### DIFF
--- a/source/v1.15/guides/groups.html.haml
+++ b/source/v1.15/guides/groups.html.haml
@@ -105,7 +105,7 @@ title: "Managing groups of gems"
         there by running <code>bundle config</code>, which will also print out global settings
         (stored in <code>~/.bundle/config</code>), and settings set via environment variables.
         For more information on configuring bundler, please see:
-        #{link_to 'bundle config', './bundle_config.html'}
+        #{link_to_documentation "bundle_config"}
 
     .bullet
       %p.description


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

In the `Using Group` guide, there seems to be a broken link,
Link: https://bundler.io/v1.15/guides/groups.html

### What is your fix for the problem, implemented in this PR?

This commit fixes that by changing the link to use `link_to_documentation` helper and hopefully in the future, it should work as expected, Thanks!
