### PR TITLE
Fix a broken link in using bundler guide

### DIFF
--- a/source/localizable/v1.15/guides/using_bundler_in_applications.en.html.md
+++ b/source/localizable/v1.15/guides/using_bundler_in_applications.en.html.md
@@ -345,4 +345,4 @@ $ bundle update
 
 ### Running `git bisect` in projects using Bundler
 
-See [Git Bisect Guide](/git_bisect.html).
+See [Git Bisect Guide](./git_bisect.html).


### PR DESCRIPTION
### What was the end-user problem that led to this PR?
In the `Using Bundler In Applications` guide, the `git bisect` link seems to be broken.

### What is your fix for the problem, implemented in this PR?
This commit updates the link to the correct guide path.

Ref: https://bundler.io/v1.15/guides/using_bundler_in_applications.html#troubleshooting