### PR TITLE
Fix broken links to guides/groups.html

### DIFF
--- a/source/v1.16/gemfile.html.haml
+++ b/source/v1.16/gemfile.html.haml
@@ -76,7 +76,7 @@
       .notes
         In order to require gems in your <code>Gemfile</code>, you will need to call
         <code>Bundler.require</code> in your application.
-      = link_to 'Learn More: Bundler.require', './groups.html', class: 'btn btn-primary'
+      = link_to 'Learn More: Bundler.require', './guides/groups.html', class: 'btn btn-primary'
 
     .bullet
       .description
@@ -141,7 +141,7 @@
         group :test do
           gem 'rspec'
         end
-      = link_to 'Learn more: Groups', './groups.html', class: 'btn btn-primary'
+      = link_to 'Learn more: Groups', './guides/groups.html', class: 'btn btn-primary'
 
     .bullet
       .description


### PR DESCRIPTION
Broken links during move from /groups.html to /guides/groups.html (between 1.14 and 1.15)