### PR TITLE
[Man] Ensure index.txt is built for 1.16+

### DIFF
--- a/data/contributors.yml
+++ b/data/contributors.yml
@@ -1,1697 +1,1681 @@
 ---
-- :avatar_url: https://avatars1.githubusercontent.com/u/16457?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/16457?v=4&s=40
   :commits: 445
   :href: https://github.com/hone
   :name: hone
-- :avatar_url: https://avatars3.githubusercontent.com/u/9582?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/9582?v=4&s=40
   :commits: 391
   :href: https://github.com/josevalim
   :name: josevalim
-- :avatar_url: https://avatars3.githubusercontent.com/u/8471682?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/8471682?v=4&s=40
   :commits: 124
   :href: https://github.com/asutoshpalai
   :name: asutoshpalai
-- :avatar_url: https://avatars3.githubusercontent.com/u/4?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/4?v=4&s=40
   :commits: 110
   :href: https://github.com/wycats
   :name: wycats
-- :avatar_url: https://avatars1.githubusercontent.com/u/1170770?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/996377?v=4&s=40
+  :commits: 109
+  :href: https://github.com/colby-swandale
+  :name: colby-swandale
+- :avatar_url: https://avatars2.githubusercontent.com/u/1170770?v=4&s=40
   :commits: 105
   :href: https://github.com/Who828
   :name: Who828
-- :avatar_url: https://avatars3.githubusercontent.com/u/44385?v=3&s=40
-  :commits: 97
+- :avatar_url: https://avatars0.githubusercontent.com/u/44385?v=4&s=40
+  :commits: 98
   :href: https://github.com/TimMoore
   :name: TimMoore
-- :avatar_url: https://avatars3.githubusercontent.com/u/188?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/188?v=4&s=40
   :commits: 87
   :href: https://github.com/nex3
   :name: nex3
-- :avatar_url: https://avatars2.githubusercontent.com/u/10308?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/10308?v=4&s=40
   :commits: 63
   :href: https://github.com/sferik
   :name: sferik
-- :avatar_url: https://avatars3.githubusercontent.com/u/996377?v=3&s=40
-  :commits: 54
-  :href: https://github.com/colby-swandale
-  :name: colby-swandale
-- :avatar_url: https://avatars1.githubusercontent.com/u/8898?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/8898?v=4&s=40
   :commits: 53
   :href: https://github.com/joshbuddy
   :name: joshbuddy
-- :avatar_url: https://avatars2.githubusercontent.com/u/6130147?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/6130147?v=4&s=40
   :commits: 50
   :href: https://github.com/b-ggs
   :name: b-ggs
-- :avatar_url: https://avatars3.githubusercontent.com/u/8092?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/8092?v=4&s=40
   :commits: 49
   :href: https://github.com/chrismo
   :name: chrismo
-- :avatar_url: https://avatars3.githubusercontent.com/u/9689?v=3&s=40
-  :commits: 39
+- :avatar_url: https://avatars0.githubusercontent.com/u/9689?v=4&s=40
+  :commits: 40
   :href: https://github.com/andremedeiros
   :name: andremedeiros
-- :avatar_url: https://avatars3.githubusercontent.com/u/543455?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/543455?v=4&s=40
   :commits: 37
   :href: https://github.com/Koronen
   :name: Koronen
-- :avatar_url: https://avatars3.githubusercontent.com/u/278?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/278?v=4&s=40
   :commits: 33
   :href: https://github.com/gnufied
   :name: gnufied
-- :avatar_url: https://avatars1.githubusercontent.com/u/827224?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/827224?v=4&s=40
   :commits: 32
-  :href: https://github.com/agis-
-  :name: agis-
-- :avatar_url: https://avatars0.githubusercontent.com/u/148989?v=3&s=40
+  :href: https://github.com/agis
+  :name: agis
+- :avatar_url: https://avatars1.githubusercontent.com/u/385638?v=4&s=40
+  :commits: 29
+  :href: https://github.com/denniss
+  :name: denniss
+- :avatar_url: https://avatars3.githubusercontent.com/u/148989?v=4&s=40
   :commits: 29
   :href: https://github.com/esasse
   :name: esasse
-- :avatar_url: https://avatars2.githubusercontent.com/u/199?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/199?v=4&s=40
   :commits: 29
   :href: https://github.com/jeremy
   :name: jeremy
-- :avatar_url: https://avatars0.githubusercontent.com/u/2687?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/2687?v=4&s=40
   :commits: 27
   :href: https://github.com/radar
   :name: radar
-- :avatar_url: https://avatars3.githubusercontent.com/u/52642?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/52642?v=4&s=40
   :commits: 26
   :href: https://github.com/spastorino
   :name: spastorino
-- :avatar_url: https://avatars2.githubusercontent.com/u/4496338?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/4496338?v=4&s=40
   :commits: 24
   :href: https://github.com/pcarranza
   :name: pcarranza
-- :avatar_url: https://avatars0.githubusercontent.com/u/6308109?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/6308109?v=4&s=40
   :commits: 24
   :href: https://github.com/pducks32
   :name: pducks32
-- :avatar_url: https://avatars2.githubusercontent.com/u/3124?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/3124?v=4&s=40
   :commits: 24
   :href: https://github.com/tenderlove
   :name: tenderlove
-- :avatar_url: https://avatars2.githubusercontent.com/u/14514?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/14514?v=4&s=40
   :commits: 23
   :href: https://github.com/rohit
   :name: rohit
-- :avatar_url: https://avatars1.githubusercontent.com/u/8701?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/13203?v=4&s=40
+  :commits: 22
+  :href: https://github.com/koic
+  :name: koic
+- :avatar_url: https://avatars2.githubusercontent.com/u/8701?v=4&s=40
   :commits: 19
   :href: https://github.com/joshk
   :name: joshk
-- :avatar_url: https://avatars1.githubusercontent.com/u/69755?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/69755?v=4&s=40
   :commits: 18
   :href: https://github.com/eagletmt
   :name: eagletmt
-- :avatar_url: https://avatars3.githubusercontent.com/u/49391?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/1000669?v=4&s=40
+  :commits: 17
+  :href: https://github.com/JuanitoFatas
+  :name: JuanitoFatas
+- :avatar_url: https://avatars0.githubusercontent.com/u/314014?v=4&s=40
+  :commits: 17
+  :href: https://github.com/NickLaMuro
+  :name: NickLaMuro
+- :avatar_url: https://avatars0.githubusercontent.com/u/49391?v=4&s=40
   :commits: 16
   :href: https://github.com/myronmarston
   :name: myronmarston
-- :avatar_url: https://avatars0.githubusercontent.com/u/3300?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/3300?v=4&s=40
   :commits: 15
   :href: https://github.com/jherdman
   :name: jherdman
-- :avatar_url: https://avatars3.githubusercontent.com/u/680266?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/680266?v=4&s=40
   :commits: 15
   :href: https://github.com/kiela
   :name: kiela
-- :avatar_url: https://avatars1.githubusercontent.com/u/4031210?v=3&s=40
-  :commits: 15
-  :href: https://github.com/smlance
-  :name: smlance
-- :avatar_url: https://avatars2.githubusercontent.com/u/1000669?v=3&s=40
-  :commits: 14
-  :href: https://github.com/JuanitoFatas
-  :name: JuanitoFatas
-- :avatar_url: https://avatars0.githubusercontent.com/u/5774448?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/5774448?v=4&s=40
   :commits: 14
   :href: https://github.com/Shekharrajak
   :name: Shekharrajak
-- :avatar_url: https://avatars2.githubusercontent.com/u/277819?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/277819?v=4&s=40
   :commits: 14
   :href: https://github.com/zzak
   :name: zzak
-- :avatar_url: https://avatars2.githubusercontent.com/u/2749?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/15078895?v=4&s=40
+  :commits: 13
+  :href: https://github.com/arbonap
+  :name: arbonap
+- :avatar_url: https://avatars1.githubusercontent.com/u/2749?v=4&s=40
   :commits: 13
   :href: https://github.com/fabien
   :name: fabien
-- :avatar_url: https://avatars1.githubusercontent.com/u/887?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/1144873?v=4&s=40
+  :commits: 13
+  :href: https://github.com/greysteil
+  :name: greysteil
+- :avatar_url: https://avatars2.githubusercontent.com/u/887?v=4&s=40
   :commits: 13
   :href: https://github.com/mislav
   :name: mislav
-- :avatar_url: https://avatars2.githubusercontent.com/u/708692?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/708692?v=4&s=40
   :commits: 13
   :href: https://github.com/rthbound
   :name: rthbound
-- :avatar_url: https://avatars0.githubusercontent.com/u/3326332?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/3326332?v=4&s=40
   :commits: 12
   :href: https://github.com/allenzhao
   :name: allenzhao
-- :avatar_url: https://avatars1.githubusercontent.com/u/978?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/11493?v=4&s=40
+  :commits: 12
+  :href: https://github.com/amatsuda
+  :name: amatsuda
+- :avatar_url: https://avatars2.githubusercontent.com/u/978?v=4&s=40
   :commits: 12
   :href: https://github.com/cypher
   :name: cypher
-- :avatar_url: https://avatars3.githubusercontent.com/u/4614?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/12301?v=4&s=40
+  :commits: 12
+  :href: https://github.com/hsbt
+  :name: hsbt
+- :avatar_url: https://avatars0.githubusercontent.com/u/4614?v=4&s=40
   :commits: 12
   :href: https://github.com/joelmoss
   :name: joelmoss
-- :avatar_url: https://avatars0.githubusercontent.com/u/10898?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/10898?v=4&s=40
   :commits: 12
   :href: https://github.com/mvz
   :name: mvz
-- :avatar_url: https://avatars3.githubusercontent.com/u/1714?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/1714?v=4&s=40
   :commits: 12
   :href: https://github.com/xaviershay
   :name: xaviershay
-- :avatar_url: https://avatars3.githubusercontent.com/u/11493?v=3&s=40
-  :commits: 11
-  :href: https://github.com/amatsuda
-  :name: amatsuda
-- :avatar_url: https://avatars0.githubusercontent.com/u/522155?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/522155?v=4&s=40
   :commits: 11
   :href: https://github.com/kirs
   :name: kirs
-- :avatar_url: https://avatars3.githubusercontent.com/u/314014?v=3&s=40
-  :commits: 11
-  :href: https://github.com/NickLaMuro
-  :name: NickLaMuro
-- :avatar_url: https://avatars1.githubusercontent.com/u/348?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/348?v=4&s=40
   :commits: 11
   :href: https://github.com/raggi
   :name: raggi
-- :avatar_url: https://avatars1.githubusercontent.com/u/4182?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/54785?v=4&s=40
+  :commits: 10
+  :href: https://github.com/dekellum
+  :name: dekellum
+- :avatar_url: https://avatars2.githubusercontent.com/u/4182?v=4&s=40
   :commits: 10
   :href: https://github.com/luislavena
   :name: luislavena
-- :avatar_url: https://avatars3.githubusercontent.com/u/18250169?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/3386562?v=4&s=40
+  :commits: 10
+  :href: https://github.com/rubymorillo
+  :name: rubymorillo
+- :avatar_url: https://avatars2.githubusercontent.com/u/3074765?v=4&s=40
+  :commits: 9
+  :href: https://github.com/jules2689
+  :name: jules2689
+- :avatar_url: https://avatars0.githubusercontent.com/u/18250169?v=4&s=40
   :commits: 9
   :href: https://github.com/pskocik
   :name: pskocik
-- :avatar_url: https://avatars0.githubusercontent.com/u/6180?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/6180?v=4&s=40
   :commits: 8
   :href: https://github.com/carllerche
   :name: carllerche
-- :avatar_url: https://avatars3.githubusercontent.com/u/54785?v=3&s=40
-  :commits: 8
-  :href: https://github.com/dekellum
-  :name: dekellum
-- :avatar_url: https://avatars1.githubusercontent.com/u/9211?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/9211?v=4&s=40
   :commits: 8
   :href: https://github.com/dubek
   :name: dubek
-- :avatar_url: https://avatars2.githubusercontent.com/u/6811076?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/6811076?v=4&s=40
   :commits: 8
   :href: https://github.com/fredrb
   :name: fredrb
-- :avatar_url: https://avatars3.githubusercontent.com/u/27443?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/27443?v=4&s=40
   :commits: 8
   :href: https://github.com/jaym
   :name: jaym
-- :avatar_url: https://avatars2.githubusercontent.com/u/751697?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/751697?v=4&s=40
   :commits: 8
   :href: https://github.com/jendiamond
   :name: jendiamond
-- :avatar_url: https://avatars0.githubusercontent.com/u/3516115?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/3516115?v=4&s=40
   :commits: 8
   :href: https://github.com/jhhere
   :name: jhhere
-- :avatar_url: https://avatars0.githubusercontent.com/u/491877?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/491877?v=4&s=40
   :commits: 8
   :href: https://github.com/mobilutz
   :name: mobilutz
-- :avatar_url: https://avatars1.githubusercontent.com/u/12671?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/12671?v=4&s=40
   :commits: 8
   :href: https://github.com/postmodern
   :name: postmodern
-- :avatar_url: https://avatars3.githubusercontent.com/u/193936?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/193936?v=4&s=40
   :commits: 8
   :href: https://github.com/simi
   :name: simi
-- :avatar_url: https://avatars1.githubusercontent.com/u/150632?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/150632?v=4&s=40
   :commits: 8
   :href: https://github.com/smellsblue
   :name: smellsblue
-- :avatar_url: https://avatars0.githubusercontent.com/u/22220?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/22220?v=4&s=40
   :commits: 8
   :href: https://github.com/zofrex
   :name: zofrex
-- :avatar_url: https://avatars1.githubusercontent.com/u/4595174?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/645514?v=4&s=40
+  :commits: 8
+  :href: https://github.com/Zorbash
+  :name: Zorbash
+- :avatar_url: https://avatars2.githubusercontent.com/u/4595174?v=4&s=40
   :commits: 7
   :href: https://github.com/bronzdoc
   :name: bronzdoc
-- :avatar_url: https://avatars1.githubusercontent.com/u/56633?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/56633?v=4&s=40
   :commits: 7
   :href: https://github.com/chastell
   :name: chastell
-- :avatar_url: https://avatars1.githubusercontent.com/u/26941?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/26941?v=4&s=40
   :commits: 7
   :href: https://github.com/mavenraven
   :name: mavenraven
-- :avatar_url: https://avatars1.githubusercontent.com/u/290782?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/290782?v=4&s=40
   :commits: 7
   :href: https://github.com/tricknotes
   :name: tricknotes
-- :avatar_url: https://avatars3.githubusercontent.com/u/14406?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/14406?v=4&s=40
   :commits: 7
   :href: https://github.com/voxik
   :name: voxik
-- :avatar_url: https://avatars1.githubusercontent.com/u/645514?v=3&s=40
-  :commits: 7
-  :href: https://github.com/Zorbash
-  :name: Zorbash
-- :avatar_url: https://avatars2.githubusercontent.com/u/833383?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/833383?v=4&s=40
   :commits: 6
   :href: https://github.com/arthurnn
   :name: arthurnn
-- :avatar_url: https://avatars3.githubusercontent.com/u/482957?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/482957?v=4&s=40
   :commits: 6
   :href: https://github.com/as-cii
   :name: as-cii
-- :avatar_url: https://avatars0.githubusercontent.com/u/19625?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/19625?v=4&s=40
   :commits: 6
   :href: https://github.com/banyan
   :name: banyan
-- :avatar_url: https://avatars1.githubusercontent.com/u/5466070?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/5466070?v=4&s=40
   :commits: 6
   :href: https://github.com/Elffers
   :name: Elffers
-- :avatar_url: https://avatars3.githubusercontent.com/u/3128783?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/3128783?v=4&s=40
   :commits: 6
   :href: https://github.com/feministy
   :name: feministy
-- :avatar_url: https://avatars3.githubusercontent.com/u/80815?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/80815?v=4&s=40
   :commits: 6
   :href: https://github.com/gretel
   :name: gretel
-- :avatar_url: https://avatars0.githubusercontent.com/u/5034?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/5758789?v=4&s=40
+  :commits: 6
+  :href: https://github.com/gwerbin
+  :name: gwerbin
+- :avatar_url: https://avatars3.githubusercontent.com/u/5034?v=4&s=40
   :commits: 6
   :href: https://github.com/lukaso
   :name: lukaso
-- :avatar_url: https://avatars3.githubusercontent.com/u/97317?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/97317?v=4&s=40
   :commits: 6
   :href: https://github.com/mipearson
   :name: mipearson
-- :avatar_url: https://avatars3.githubusercontent.com/u/1003758?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/1003758?v=4&s=40
   :commits: 6
   :href: https://github.com/savionok
   :name: savionok
-- :avatar_url: https://avatars1.githubusercontent.com/u/3360?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/3360?v=4&s=40
   :commits: 6
   :href: https://github.com/timblair
   :name: timblair
-- :avatar_url: https://avatars3.githubusercontent.com/u/93058?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/93058?v=4&s=40
   :commits: 6
   :href: https://github.com/zachahn
   :name: zachahn
-- :avatar_url: https://avatars2.githubusercontent.com/u/226510?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/226510?v=4&s=40
   :commits: 5
   :href: https://github.com/A5308Y
   :name: A5308Y
-- :avatar_url: https://avatars3.githubusercontent.com/u/3117356?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/3117356?v=4&s=40
   :commits: 5
   :href: https://github.com/BenMorganIO
   :name: BenMorganIO
-- :avatar_url: https://avatars2.githubusercontent.com/u/2460418?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/2460418?v=4&s=40
   :commits: 5
   :href: https://github.com/brchristian
   :name: brchristian
-- :avatar_url: https://avatars2.githubusercontent.com/u/47985?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/47985?v=4&s=40
   :commits: 5
   :href: https://github.com/citizen428
   :name: citizen428
-- :avatar_url: https://avatars3.githubusercontent.com/u/11994?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/11994?v=4&s=40
   :commits: 5
   :href: https://github.com/cldwalker
   :name: cldwalker
-- :avatar_url: https://avatars1.githubusercontent.com/u/4205?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/4205?v=4&s=40
   :commits: 5
   :href: https://github.com/cowboyd
   :name: cowboyd
-- :avatar_url: https://avatars0.githubusercontent.com/u/3844?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/3844?v=4&s=40
   :commits: 5
   :href: https://github.com/dougbarth
   :name: dougbarth
-- :avatar_url: https://avatars3.githubusercontent.com/u/1164655?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/1164655?v=4&s=40
   :commits: 5
   :href: https://github.com/DTrierweiler
   :name: DTrierweiler
-- :avatar_url: https://avatars3.githubusercontent.com/u/7?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/7?v=4&s=40
   :commits: 5
   :href: https://github.com/evanphx
   :name: evanphx
-- :avatar_url: https://avatars0.githubusercontent.com/u/1156987?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/1156987?v=4&s=40
   :commits: 5
   :href: https://github.com/hmistry
   :name: hmistry
-- :avatar_url: https://avatars1.githubusercontent.com/u/95995?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/95995?v=4&s=40
   :commits: 5
   :href: https://github.com/jlsuttles
   :name: jlsuttles
-- :avatar_url: https://avatars3.githubusercontent.com/u/19339?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/19339?v=4&s=40
   :commits: 5
   :href: https://github.com/jrafanie
   :name: jrafanie
-- :avatar_url: https://avatars1.githubusercontent.com/u/66112?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/66112?v=4&s=40
   :commits: 5
   :href: https://github.com/koraktor
   :name: koraktor
-- :avatar_url: https://avatars3.githubusercontent.com/u/454857?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/454857?v=4&s=40
   :commits: 5
   :href: https://github.com/lamont-granquist
   :name: lamont-granquist
-- :avatar_url: https://avatars3.githubusercontent.com/u/176234?v=3&s=40
-  :commits: 5
-  :href: https://github.com/larskanis
-  :name: larskanis
-- :avatar_url: https://avatars3.githubusercontent.com/u/189693?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/189693?v=4&s=40
   :commits: 5
   :href: https://github.com/mattbrictson
   :name: mattbrictson
-- :avatar_url: https://avatars3.githubusercontent.com/u/780485?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/780485?v=4&s=40
   :commits: 5
   :href: https://github.com/mistydemeo
   :name: mistydemeo
-- :avatar_url: https://avatars0.githubusercontent.com/u/101456?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/101456?v=4&s=40
   :commits: 5
   :href: https://github.com/MSNexploder
   :name: MSNexploder
-- :avatar_url: https://avatars1.githubusercontent.com/u/59744?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/211?v=4&s=40
+  :commits: 5
+  :href: https://github.com/olleolleolle
+  :name: olleolleolle
+- :avatar_url: https://avatars2.githubusercontent.com/u/59744?v=4&s=40
   :commits: 5
   :href: https://github.com/schneems
   :name: schneems
-- :avatar_url: https://avatars0.githubusercontent.com/u/461132?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/461132?v=4&s=40
   :commits: 5
   :href: https://github.com/sol
   :name: sol
-- :avatar_url: https://avatars3.githubusercontent.com/u/1014482?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/23248934?v=4&s=40
+  :commits: 4
+  :href: https://github.com/ajwann
+  :name: ajwann
+- :avatar_url: https://avatars0.githubusercontent.com/u/1014482?v=4&s=40
   :commits: 4
   :href: https://github.com/cdwort
   :name: cdwort
-- :avatar_url: https://avatars3.githubusercontent.com/u/1588255?v=3&s=40
-  :commits: 4
-  :href: https://github.com/CosmicCat
-  :name: CosmicCat
-- :avatar_url: https://avatars0.githubusercontent.com/u/37162?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/37162?v=4&s=40
   :commits: 4
   :href: https://github.com/danielsdeleo
   :name: danielsdeleo
-- :avatar_url: https://avatars2.githubusercontent.com/u/439223?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/439223?v=4&s=40
   :commits: 4
   :href: https://github.com/databus23
   :name: databus23
-- :avatar_url: https://avatars2.githubusercontent.com/u/385638?v=3&s=40
-  :commits: 4
-  :href: https://github.com/denniss
-  :name: denniss
-- :avatar_url: https://avatars0.githubusercontent.com/u/939106?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/939106?v=4&s=40
   :commits: 4
   :href: https://github.com/diegosteiner
   :name: diegosteiner
-- :avatar_url: https://avatars0.githubusercontent.com/u/1457730?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/215018?v=4&s=40
+  :commits: 4
+  :href: https://github.com/fotanus
+  :name: fotanus
+- :avatar_url: https://avatars3.githubusercontent.com/u/1457730?v=4&s=40
   :commits: 4
   :href: https://github.com/gjaldon
   :name: gjaldon
-- :avatar_url: https://avatars3.githubusercontent.com/u/94782?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/94782?v=4&s=40
   :commits: 4
   :href: https://github.com/ixti
   :name: ixti
-- :avatar_url: https://avatars0.githubusercontent.com/u/8129357?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/8129357?v=4&s=40
   :commits: 4
   :href: https://github.com/jonathanpike
   :name: jonathanpike
-- :avatar_url: https://avatars1.githubusercontent.com/u/137?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/137?v=4&s=40
   :commits: 4
   :href: https://github.com/josh
   :name: josh
-- :avatar_url: https://avatars1.githubusercontent.com/u/3358621?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/3358621?v=4&s=40
   :commits: 4
   :href: https://github.com/keiths-osc
   :name: keiths-osc
-- :avatar_url: https://avatars1.githubusercontent.com/u/257689?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/257689?v=4&s=40
   :commits: 4
   :href: https://github.com/kerrizor
   :name: kerrizor
-- :avatar_url: https://avatars1.githubusercontent.com/u/17034?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/17034?v=4&s=40
   :commits: 4
   :href: https://github.com/kevmoo
   :name: kevmoo
-- :avatar_url: https://avatars1.githubusercontent.com/u/10236?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/10236?v=4&s=40
   :commits: 4
   :href: https://github.com/knu
   :name: knu
-- :avatar_url: https://avatars3.githubusercontent.com/u/1581372?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/176234?v=4&s=40
+  :commits: 4
+  :href: https://github.com/larskanis
+  :name: larskanis
+- :avatar_url: https://avatars0.githubusercontent.com/u/1581372?v=4&s=40
   :commits: 4
   :href: https://github.com/MafcoCinco
   :name: MafcoCinco
-- :avatar_url: https://avatars3.githubusercontent.com/u/66243?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/66243?v=4&s=40
   :commits: 4
   :href: https://github.com/mcfiredrill
   :name: mcfiredrill
-- :avatar_url: https://avatars2.githubusercontent.com/u/33111?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/16700?v=4&s=40
   :commits: 4
-  :href: https://github.com/okkez
-  :name: okkez
-- :avatar_url: https://avatars1.githubusercontent.com/u/150387?v=3&s=40
+  :href: https://github.com/nobu
+  :name: nobu
+- :avatar_url: https://avatars2.githubusercontent.com/u/150387?v=4&s=40
   :commits: 4
   :href: https://github.com/pjvds
   :name: pjvds
-- :avatar_url: https://avatars1.githubusercontent.com/u/103822?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/103822?v=4&s=40
   :commits: 4
   :href: https://github.com/pmahoney
   :name: pmahoney
-- :avatar_url: https://avatars1.githubusercontent.com/u/621238?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/621238?v=4&s=40
   :commits: 4
   :href: https://github.com/prathamesh-sonpatki
   :name: prathamesh-sonpatki
-- :avatar_url: https://avatars2.githubusercontent.com/u/11460?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/11460?v=4&s=40
   :commits: 4
   :href: https://github.com/pwnall
   :name: pwnall
-- :avatar_url: https://avatars1.githubusercontent.com/u/8061074?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/8061074?v=4&s=40
   :commits: 4
   :href: https://github.com/roseweixel
   :name: roseweixel
-- :avatar_url: https://avatars0.githubusercontent.com/u/2503?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/2503?v=4&s=40
   :commits: 4
   :href: https://github.com/rsutphin
   :name: rsutphin
-- :avatar_url: https://avatars0.githubusercontent.com/u/75448?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/75448?v=4&s=40
   :commits: 4
   :href: https://github.com/sanemat
   :name: sanemat
-- :avatar_url: https://avatars1.githubusercontent.com/u/50139?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/50139?v=4&s=40
   :commits: 4
   :href: https://github.com/smathy
   :name: smathy
-- :avatar_url: https://avatars3.githubusercontent.com/u/7680662?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/7680662?v=4&s=40
   :commits: 4
   :href: https://github.com/sonalkr132
   :name: sonalkr132
-- :avatar_url: https://avatars2.githubusercontent.com/u/517365?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/517365?v=4&s=40
   :commits: 4
   :href: https://github.com/tryba
   :name: tryba
-- :avatar_url: https://avatars0.githubusercontent.com/u/252023?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/252023?v=4&s=40
   :commits: 4
   :href: https://github.com/vassilevsky
   :name: vassilevsky
-- :avatar_url: https://avatars1.githubusercontent.com/u/40264?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/2655?v=4&s=40
+  :commits: 4
+  :href: https://github.com/walf443
+  :name: walf443
+- :avatar_url: https://avatars2.githubusercontent.com/u/40264?v=4&s=40
   :commits: 3
   :href: https://github.com/bowsersenior
   :name: bowsersenior
-- :avatar_url: https://avatars3.githubusercontent.com/u/4805?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/4805?v=4&s=40
   :commits: 3
   :href: https://github.com/cgriego
   :name: cgriego
-- :avatar_url: https://avatars2.githubusercontent.com/u/98429?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/98429?v=4&s=40
   :commits: 3
   :href: https://github.com/chalkos
   :name: chalkos
-- :avatar_url: https://avatars2.githubusercontent.com/u/128243?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/128243?v=4&s=40
   :commits: 3
   :href: https://github.com/coderanger
   :name: coderanger
-- :avatar_url: https://avatars3.githubusercontent.com/u/1888700?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/1888700?v=4&s=40
   :commits: 3
   :href: https://github.com/dbloete
   :name: dbloete
-- :avatar_url: https://avatars3.githubusercontent.com/u/33736?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/33736?v=4&s=40
   :commits: 3
   :href: https://github.com/deepj
   :name: deepj
-- :avatar_url: https://avatars0.githubusercontent.com/u/7216586?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/7216586?v=4&s=40
   :commits: 3
   :href: https://github.com/DevRubySlippers
   :name: DevRubySlippers
-- :avatar_url: https://avatars0.githubusercontent.com/u/90865?v=3&s=40
-  :commits: 3
-  :href: https://github.com/dtognazzini
-  :name: dtognazzini
-- :avatar_url: https://avatars3.githubusercontent.com/u/1585126?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/1585126?v=4&s=40
   :commits: 3
   :href: https://github.com/EduardoBautista
   :name: EduardoBautista
-- :avatar_url: https://avatars2.githubusercontent.com/u/215018?v=3&s=40
-  :commits: 3
-  :href: https://github.com/fotanus
-  :name: fotanus
-- :avatar_url: https://avatars0.githubusercontent.com/u/40720?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/40720?v=4&s=40
   :commits: 3
   :href: https://github.com/frsyuki
   :name: frsyuki
-- :avatar_url: https://avatars3.githubusercontent.com/u/456459?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/456459?v=4&s=40
   :commits: 3
   :href: https://github.com/grzuy
   :name: grzuy
-- :avatar_url: https://avatars1.githubusercontent.com/u/84460?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/5669259?v=4&s=40
+  :commits: 3
+  :href: https://github.com/gxespino
+  :name: gxespino
+- :avatar_url: https://avatars2.githubusercontent.com/u/84460?v=4&s=40
   :commits: 3
   :href: https://github.com/hwartig
   :name: hwartig
-- :avatar_url: https://avatars2.githubusercontent.com/u/1355481?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/37040?v=4&s=40
+  :commits: 3
+  :href: https://github.com/igorbozato
+  :name: igorbozato
+- :avatar_url: https://avatars1.githubusercontent.com/u/1355481?v=4&s=40
   :commits: 3
   :href: https://github.com/jisaacks
   :name: jisaacks
-- :avatar_url: https://avatars3.githubusercontent.com/u/5768468?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/5768468?v=4&s=40
   :commits: 3
-  :href: https://github.com/lynnco
-  :name: lynnco
-- :avatar_url: https://avatars3.githubusercontent.com/u/24899?v=3&s=40
+  :href: https://github.com/lynncyrin
+  :name: lynncyrin
+- :avatar_url: https://avatars0.githubusercontent.com/u/24899?v=4&s=40
   :commits: 3
   :href: https://github.com/maxjustus
   :name: maxjustus
-- :avatar_url: https://avatars0.githubusercontent.com/u/20990?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/20990?v=4&s=40
   :commits: 3
   :href: https://github.com/MJIO
   :name: MJIO
-- :avatar_url: https://avatars0.githubusercontent.com/u/3959?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/3959?v=4&s=40
   :commits: 3
   :href: https://github.com/mrkn
   :name: mrkn
-- :avatar_url: https://avatars1.githubusercontent.com/u/139536?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/139536?v=4&s=40
   :commits: 3
   :href: https://github.com/ndbroadbent
   :name: ndbroadbent
-- :avatar_url: https://avatars3.githubusercontent.com/u/118781?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/118781?v=4&s=40
   :commits: 3
   :href: https://github.com/nubbel
   :name: nubbel
-- :avatar_url: https://avatars1.githubusercontent.com/u/4451852?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/33111?v=4&s=40
+  :commits: 3
+  :href: https://github.com/okkez
+  :name: okkez
+- :avatar_url: https://avatars2.githubusercontent.com/u/4451852?v=4&s=40
   :commits: 3
   :href: https://github.com/opiethehokie
   :name: opiethehokie
-- :avatar_url: https://avatars0.githubusercontent.com/u/456508?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/456508?v=4&s=40
   :commits: 3
   :href: https://github.com/pascalh1011
   :name: pascalh1011
-- :avatar_url: https://avatars3.githubusercontent.com/u/32618?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/32618?v=4&s=40
   :commits: 3
   :href: https://github.com/pmenglund
   :name: pmenglund
-- :avatar_url: https://avatars3.githubusercontent.com/u/7426?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/7426?v=4&s=40
   :commits: 3
   :href: https://github.com/QuBiT
   :name: QuBiT
-- :avatar_url: https://avatars3.githubusercontent.com/u/476418?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/476418?v=4&s=40
   :commits: 3
   :href: https://github.com/richo
   :name: richo
-- :avatar_url: https://avatars0.githubusercontent.com/u/97996?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/97996?v=4&s=40
   :commits: 3
   :href: https://github.com/rkbodenner
   :name: rkbodenner
-- :avatar_url: https://avatars0.githubusercontent.com/u/311914?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/311914?v=4&s=40
   :commits: 3
   :href: https://github.com/rrrene
   :name: rrrene
-- :avatar_url: https://avatars2.githubusercontent.com/u/20831?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/20831?v=4&s=40
   :commits: 3
   :href: https://github.com/rwilcox
   :name: rwilcox
-- :avatar_url: https://avatars0.githubusercontent.com/u/35549?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/35549?v=4&s=40
   :commits: 3
   :href: https://github.com/rykov
   :name: rykov
-- :avatar_url: https://avatars1.githubusercontent.com/u/20158?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/15377?v=4&s=40
+  :commits: 3
+  :href: https://github.com/shyouhei
+  :name: shyouhei
+- :avatar_url: https://avatars2.githubusercontent.com/u/20158?v=4&s=40
   :commits: 3
   :href: https://github.com/spraints
   :name: spraints
-- :avatar_url: https://avatars3.githubusercontent.com/u/658?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/141908?v=4&s=40
+  :commits: 3
+  :href: https://github.com/stefansedich
+  :name: stefansedich
+- :avatar_url: https://avatars0.githubusercontent.com/u/658?v=4&s=40
   :commits: 3
   :href: https://github.com/stephencelis
   :name: stephencelis
-- :avatar_url: https://avatars2.githubusercontent.com/u/11580?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/13248?v=4&s=40
+  :commits: 3
+  :href: https://github.com/steved
+  :name: steved
+- :avatar_url: https://avatars1.githubusercontent.com/u/11580?v=4&s=40
   :commits: 3
   :href: https://github.com/sumbach
   :name: sumbach
-- :avatar_url: https://avatars3.githubusercontent.com/u/9863?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/9863?v=4&s=40
   :commits: 3
   :href: https://github.com/sunaku
   :name: sunaku
-- :avatar_url: https://avatars1.githubusercontent.com/u/855881?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/855881?v=4&s=40
   :commits: 3
   :href: https://github.com/tdumitrescu
   :name: tdumitrescu
-- :avatar_url: https://avatars0.githubusercontent.com/u/26856?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/26856?v=4&s=40
   :commits: 3
   :href: https://github.com/tigris
   :name: tigris
-- :avatar_url: https://avatars1.githubusercontent.com/u/46235?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/46235?v=4&s=40
   :commits: 3
   :href: https://github.com/timfel
   :name: timfel
-- :avatar_url: https://avatars0.githubusercontent.com/u/23423?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/23423?v=4&s=40
   :commits: 3
   :href: https://github.com/trans
   :name: trans
-- :avatar_url: https://avatars0.githubusercontent.com/u/1298231?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/1298231?v=4&s=40
   :commits: 3
   :href: https://github.com/will-in-wi
   :name: will-in-wi
-- :avatar_url: https://avatars3.githubusercontent.com/u/174?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/174?v=4&s=40
   :commits: 3
   :href: https://github.com/wilson
   :name: wilson
-- :avatar_url: https://avatars0.githubusercontent.com/u/56541?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/56541?v=4&s=40
   :commits: 3
   :href: https://github.com/wjordan
   :name: wjordan
-- :avatar_url: https://avatars3.githubusercontent.com/u/3321?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/3321?v=4&s=40
   :commits: 3
   :href: https://github.com/wuputah
   :name: wuputah
-- :avatar_url: https://avatars1.githubusercontent.com/u/1756640?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/1756640?v=4&s=40
   :commits: 3
   :href: https://github.com/yuuki1224
   :name: yuuki1224
-- :avatar_url: https://avatars0.githubusercontent.com/u/26175?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/26175?v=4&s=40
   :commits: 3
   :href: https://github.com/zeha
   :name: zeha
-- :avatar_url: https://avatars0.githubusercontent.com/u/333180?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/333180?v=4&s=40
   :commits: 2
   :href: https://github.com/5t111111
   :name: 5t111111
-- :avatar_url: https://avatars0.githubusercontent.com/u/16841?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/16841?v=4&s=40
   :commits: 2
   :href: https://github.com/agenteo
   :name: agenteo
-- :avatar_url: https://avatars1.githubusercontent.com/u/26099?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/26099?v=4&s=40
   :commits: 2
   :href: https://github.com/akahn
   :name: akahn
-- :avatar_url: https://avatars0.githubusercontent.com/u/136095?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/7259082?v=4&s=40
+  :commits: 2
+  :href: https://github.com/alextaylor000
+  :name: alextaylor000
+- :avatar_url: https://avatars3.githubusercontent.com/u/136095?v=4&s=40
   :commits: 2
   :href: https://github.com/andreagoulet
   :name: andreagoulet
-- :avatar_url: https://avatars1.githubusercontent.com/u/917945?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/917945?v=4&s=40
   :commits: 2
   :href: https://github.com/aroben
   :name: aroben
-- :avatar_url: https://avatars1.githubusercontent.com/u/128298?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/128298?v=4&s=40
   :commits: 2
   :href: https://github.com/arronmabrey
   :name: arronmabrey
-- :avatar_url: https://avatars3.githubusercontent.com/u/54611?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/54611?v=4&s=40
   :commits: 2
   :href: https://github.com/aughr
   :name: aughr
-- :avatar_url: https://avatars3.githubusercontent.com/u/93578?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/93578?v=4&s=40
   :commits: 2
   :href: https://github.com/biow0lf
   :name: biow0lf
-- :avatar_url: https://avatars0.githubusercontent.com/u/133308?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/133308?v=4&s=40
   :commits: 2
   :href: https://github.com/blackxored
   :name: blackxored
-- :avatar_url: https://avatars0.githubusercontent.com/u/764206?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/764206?v=4&s=40
   :commits: 2
   :href: https://github.com/BrentWheeldon
   :name: BrentWheeldon
-- :avatar_url: https://avatars3.githubusercontent.com/u/49108?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/49108?v=4&s=40
   :commits: 2
   :href: https://github.com/brettporter
   :name: brettporter
-- :avatar_url: https://avatars0.githubusercontent.com/u/9830?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/9830?v=4&s=40
   :commits: 2
   :href: https://github.com/cheald
   :name: cheald
-- :avatar_url: https://avatars3.githubusercontent.com/u/77704?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/77704?v=4&s=40
   :commits: 2
   :href: https://github.com/chipiga
   :name: chipiga
-- :avatar_url: https://avatars3.githubusercontent.com/u/44939?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/44939?v=4&s=40
   :commits: 2
   :href: https://github.com/cmeiklejohn
   :name: cmeiklejohn
-- :avatar_url: https://avatars2.githubusercontent.com/u/64469?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/64469?v=4&s=40
   :commits: 2
   :href: https://github.com/coop
   :name: coop
-- :avatar_url: https://avatars1.githubusercontent.com/u/2912?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/2912?v=4&s=40
   :commits: 2
   :href: https://github.com/crowbot
   :name: crowbot
-- :avatar_url: https://avatars0.githubusercontent.com/u/13015?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/13015?v=4&s=40
   :commits: 2
   :href: https://github.com/csgui
   :name: csgui
-- :avatar_url: https://avatars0.githubusercontent.com/u/173457?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/173457?v=4&s=40
   :commits: 2
   :href: https://github.com/csquared
   :name: csquared
-- :avatar_url: https://avatars1.githubusercontent.com/u/161157?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/161157?v=4&s=40
   :commits: 2
   :href: https://github.com/danieltdt
   :name: danieltdt
-- :avatar_url: https://avatars2.githubusercontent.com/u/2182?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/2182?v=4&s=40
   :commits: 2
   :href: https://github.com/danp
   :name: danp
-- :avatar_url: https://avatars3.githubusercontent.com/u/90268?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/90268?v=4&s=40
   :commits: 2
   :href: https://github.com/davidblondeau
   :name: davidblondeau
-- :avatar_url: https://avatars1.githubusercontent.com/u/3308?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/3308?v=4&s=40
   :commits: 2
   :href: https://github.com/ddollar
   :name: ddollar
-- :avatar_url: https://avatars3.githubusercontent.com/u/2741?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/2887858?v=4&s=40
+  :commits: 2
+  :href: https://github.com/deivid-rodriguez
+  :name: deivid-rodriguez
+- :avatar_url: https://avatars0.githubusercontent.com/u/2741?v=4&s=40
   :commits: 2
   :href: https://github.com/dhh
   :name: dhh
-- :avatar_url: https://avatars2.githubusercontent.com/u/1952789?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/1952789?v=4&s=40
   :commits: 2
   :href: https://github.com/dmcclory
   :name: dmcclory
-- :avatar_url: https://avatars0.githubusercontent.com/u/692528?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/692528?v=4&s=40
   :commits: 2
   :href: https://github.com/echohead
   :name: echohead
-- :avatar_url: https://avatars1.githubusercontent.com/u/5470?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/5470?v=4&s=40
   :commits: 2
   :href: https://github.com/Empact
   :name: Empact
-- :avatar_url: https://avatars0.githubusercontent.com/u/470?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/470?v=4&s=40
   :commits: 2
   :href: https://github.com/eric
   :name: eric
-- :avatar_url: https://avatars1.githubusercontent.com/u/43233?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/43233?v=4&s=40
   :commits: 2
   :href: https://github.com/eric1234
   :name: eric1234
-- :avatar_url: https://avatars3.githubusercontent.com/u/909587?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/909587?v=4&s=40
   :commits: 2
   :href: https://github.com/felixbuenemann
   :name: felixbuenemann
-- :avatar_url: https://avatars1.githubusercontent.com/u/261548?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/261548?v=4&s=40
   :commits: 2
   :href: https://github.com/fnichol
   :name: fnichol
-- :avatar_url: https://avatars0.githubusercontent.com/u/346068?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/346068?v=4&s=40
   :commits: 2
   :href: https://github.com/fny
   :name: fny
-- :avatar_url: https://avatars3.githubusercontent.com/u/7095?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/7095?v=4&s=40
   :commits: 2
   :href: https://github.com/gaffneyc
   :name: gaffneyc
-- :avatar_url: https://avatars3.githubusercontent.com/u/4138?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/4138?v=4&s=40
   :commits: 2
   :href: https://github.com/geemus
   :name: geemus
-- :avatar_url: https://avatars0.githubusercontent.com/u/974?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/974?v=4&s=40
   :commits: 2
   :href: https://github.com/gilesbowkett
   :name: gilesbowkett
-- :avatar_url: https://avatars3.githubusercontent.com/u/202230?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/202230?v=4&s=40
   :commits: 2
   :href: https://github.com/glennpratt
   :name: glennpratt
-- :avatar_url: https://avatars1.githubusercontent.com/u/26832?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/26832?v=4&s=40
   :commits: 2
   :href: https://github.com/hasimo
   :name: hasimo
-- :avatar_url: https://avatars0.githubusercontent.com/u/10135?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/10135?v=4&s=40
   :commits: 2
   :href: https://github.com/headius
   :name: headius
-- :avatar_url: https://avatars3.githubusercontent.com/u/898442?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/25674779?v=4&s=40
+  :commits: 2
+  :href: https://github.com/HippoDippo
+  :name: HippoDippo
+- :avatar_url: https://avatars0.githubusercontent.com/u/898442?v=4&s=40
   :commits: 2
   :href: https://github.com/hirochachacha
   :name: hirochachacha
-- :avatar_url: https://avatars2.githubusercontent.com/u/12301?v=3&s=40
-  :commits: 2
-  :href: https://github.com/hsbt
-  :name: hsbt
-- :avatar_url: https://avatars1.githubusercontent.com/u/479?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/479?v=4&s=40
   :commits: 2
   :href: https://github.com/jackdempsey
   :name: jackdempsey
-- :avatar_url: https://avatars0.githubusercontent.com/u/10033?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/10033?v=4&s=40
   :commits: 2
   :href: https://github.com/jacobo
   :name: jacobo
-- :avatar_url: https://avatars1.githubusercontent.com/u/59449?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/59449?v=4&s=40
   :commits: 2
   :href: https://github.com/jamesotron
   :name: jamesotron
-- :avatar_url: https://avatars1.githubusercontent.com/u/111510?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/111510?v=4&s=40
   :commits: 2
   :href: https://github.com/janlelis
   :name: janlelis
-- :avatar_url: https://avatars0.githubusercontent.com/u/174160?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/174160?v=4&s=40
   :commits: 2
   :href: https://github.com/jarmo
   :name: jarmo
-- :avatar_url: https://avatars0.githubusercontent.com/u/130504?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/130504?v=4&s=40
   :commits: 2
   :href: https://github.com/jasonrclark
   :name: jasonrclark
-- :avatar_url: https://avatars2.githubusercontent.com/u/2377?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/2377?v=4&s=40
   :commits: 2
   :href: https://github.com/jdelStrother
   :name: jdelStrother
-- :avatar_url: https://avatars2.githubusercontent.com/u/161737?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/161737?v=4&s=40
   :commits: 2
   :href: https://github.com/jetaggart
   :name: jetaggart
-- :avatar_url: https://avatars3.githubusercontent.com/u/10274?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/10274?v=4&s=40
   :commits: 2
   :href: https://github.com/jgeiger
   :name: jgeiger
-- :avatar_url: https://avatars3.githubusercontent.com/u/524?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/524?v=4&s=40
   :commits: 2
   :href: https://github.com/jredville
   :name: jredville
-- :avatar_url: https://avatars0.githubusercontent.com/u/149304?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/149304?v=4&s=40
   :commits: 2
   :href: https://github.com/jrochkind
   :name: jrochkind
-- :avatar_url: https://avatars1.githubusercontent.com/u/3074765?v=3&s=40
-  :commits: 2
-  :href: https://github.com/jules2689
-  :name: jules2689
-- :avatar_url: https://avatars3.githubusercontent.com/u/987742?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/987742?v=4&s=40
   :commits: 2
   :href: https://github.com/kcurtin
   :name: kcurtin
-- :avatar_url: https://avatars2.githubusercontent.com/u/400299?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/400299?v=4&s=40
   :commits: 2
   :href: https://github.com/kgrz
   :name: kgrz
-- :avatar_url: https://avatars1.githubusercontent.com/u/83021?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/83021?v=4&s=40
   :commits: 2
   :href: https://github.com/korobkov
   :name: korobkov
-- :avatar_url: https://avatars0.githubusercontent.com/u/121322?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/121322?v=4&s=40
   :commits: 2
   :href: https://github.com/leereilly
   :name: leereilly
-- :avatar_url: https://avatars0.githubusercontent.com/u/14548?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/14548?v=4&s=40
   :commits: 2
   :href: https://github.com/lenary
   :name: lenary
-- :avatar_url: https://avatars3.githubusercontent.com/u/80978?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/80978?v=4&s=40
   :commits: 2
   :href: https://github.com/lucasmazza
   :name: lucasmazza
-- :avatar_url: https://avatars2.githubusercontent.com/u/136325?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/136325?v=4&s=40
   :commits: 2
   :href: https://github.com/m1k3
   :name: m1k3
-- :avatar_url: https://avatars0.githubusercontent.com/u/18589982?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/591257?v=4&s=40
+  :commits: 2
+  :href: https://github.com/mal
+  :name: mal
+- :avatar_url: https://avatars3.githubusercontent.com/u/18589982?v=4&s=40
   :commits: 2
   :href: https://github.com/mastfissh
   :name: mastfissh
-- :avatar_url: https://avatars0.githubusercontent.com/u/22815?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/22815?v=4&s=40
   :commits: 2
   :href: https://github.com/mbirk
   :name: mbirk
-- :avatar_url: https://avatars1.githubusercontent.com/u/80635?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/290611?v=4&s=40
+  :commits: 2
+  :href: https://github.com/meganemura
+  :name: meganemura
+- :avatar_url: https://avatars2.githubusercontent.com/u/80635?v=4&s=40
   :commits: 2
   :href: https://github.com/mheffner
   :name: mheffner
-- :avatar_url: https://avatars1.githubusercontent.com/u/14829?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/14829?v=4&s=40
   :commits: 2
   :href: https://github.com/moeffju
   :name: moeffju
-- :avatar_url: https://avatars1.githubusercontent.com/u/10766?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/10766?v=4&s=40
   :commits: 2
   :href: https://github.com/morgoth
   :name: morgoth
-- :avatar_url: https://avatars2.githubusercontent.com/u/755?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/755?v=4&s=40
   :commits: 2
   :href: https://github.com/myabc
   :name: myabc
-- :avatar_url: https://avatars0.githubusercontent.com/u/4057385?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/4057385?v=4&s=40
   :commits: 2
   :href: https://github.com/netskin-ci
   :name: netskin-ci
-- :avatar_url: https://avatars3.githubusercontent.com/u/385448?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/385448?v=4&s=40
   :commits: 2
   :href: https://github.com/Nitrodist
   :name: Nitrodist
-- :avatar_url: https://avatars2.githubusercontent.com/u/360800?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/360800?v=4&s=40
   :commits: 2
   :href: https://github.com/njam
   :name: njam
-- :avatar_url: https://avatars0.githubusercontent.com/u/691898?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/691898?v=4&s=40
   :commits: 2
   :href: https://github.com/ogra
   :name: ogra
-- :avatar_url: https://avatars3.githubusercontent.com/u/153388?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/153388?v=4&s=40
   :commits: 2
   :href: https://github.com/ojab
   :name: ojab
-- :avatar_url: https://avatars3.githubusercontent.com/u/65950?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/65950?v=4&s=40
   :commits: 2
   :href: https://github.com/olivierlacan
   :name: olivierlacan
-- :avatar_url: https://avatars3.githubusercontent.com/u/211?v=3&s=40
-  :commits: 2
-  :href: https://github.com/olleolleolle
-  :name: olleolleolle
-- :avatar_url: https://avatars0.githubusercontent.com/u/723421?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/723421?v=4&s=40
   :commits: 2
   :href: https://github.com/phil-monroe
   :name: phil-monroe
-- :avatar_url: https://avatars2.githubusercontent.com/u/553697?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/553697?v=4&s=40
   :commits: 2
   :href: https://github.com/punkle
   :name: punkle
-- :avatar_url: https://avatars2.githubusercontent.com/u/4469761?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/4469761?v=4&s=40
   :commits: 2
   :href: https://github.com/qblake
   :name: qblake
-- :avatar_url: https://avatars0.githubusercontent.com/u/823277?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/47848?v=4&s=40
+  :commits: 2
+  :href: https://github.com/rafaelfranca
+  :name: rafaelfranca
+- :avatar_url: https://avatars3.githubusercontent.com/u/823277?v=4&s=40
   :commits: 2
   :href: https://github.com/rhysd
   :name: rhysd
-- :avatar_url: https://avatars2.githubusercontent.com/u/364390?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/364390?v=4&s=40
   :commits: 2
   :href: https://github.com/richardkmichael
   :name: richardkmichael
-- :avatar_url: https://avatars2.githubusercontent.com/u/14323?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/14323?v=4&s=40
   :commits: 2
   :href: https://github.com/robertwahler
   :name: robertwahler
-- :avatar_url: https://avatars0.githubusercontent.com/u/1152728?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/1152728?v=4&s=40
   :commits: 2
   :href: https://github.com/ryanfox1985
   :name: ryanfox1985
-- :avatar_url: https://avatars2.githubusercontent.com/u/5535625?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/5535625?v=4&s=40
   :commits: 2
   :href: https://github.com/sandlerr
   :name: sandlerr
-- :avatar_url: https://avatars1.githubusercontent.com/u/50039?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/50039?v=4&s=40
   :commits: 2
   :href: https://github.com/sdhull
   :name: sdhull
-- :avatar_url: https://avatars3.githubusercontent.com/u/4951910?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/4951910?v=4&s=40
   :commits: 2
   :href: https://github.com/sealocal
   :name: sealocal
-- :avatar_url: https://avatars0.githubusercontent.com/u/688886?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/688886?v=4&s=40
   :commits: 2
   :href: https://github.com/seanlinsley
   :name: seanlinsley
-- :avatar_url: https://avatars3.githubusercontent.com/u/74080?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/74080?v=4&s=40
   :commits: 2
   :href: https://github.com/shtirlic
   :name: shtirlic
-- :avatar_url: https://avatars0.githubusercontent.com/u/97400?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/97400?v=4&s=40
   :commits: 2
   :href: https://github.com/sirupsen
   :name: sirupsen
-- :avatar_url: https://avatars3.githubusercontent.com/u/861778?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/861778?v=4&s=40
   :commits: 2
   :href: https://github.com/smlx
   :name: smlx
-- :avatar_url: https://avatars0.githubusercontent.com/u/98590?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/98590?v=4&s=40
   :commits: 2
   :href: https://github.com/spk
   :name: spk
-- :avatar_url: https://avatars1.githubusercontent.com/u/4300?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/4300?v=4&s=40
   :commits: 2
   :href: https://github.com/staugaard
   :name: staugaard
-- :avatar_url: https://avatars1.githubusercontent.com/u/1220480?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/1220480?v=4&s=40
   :commits: 2
   :href: https://github.com/steverob
   :name: steverob
-- :avatar_url: https://avatars0.githubusercontent.com/u/793084?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/793084?v=4&s=40
   :commits: 2
   :href: https://github.com/stlay
   :name: stlay
-- :avatar_url: https://avatars1.githubusercontent.com/u/7255?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/132?v=4&s=40
+  :commits: 2
+  :href: https://github.com/sunny
+  :name: sunny
+- :avatar_url: https://avatars2.githubusercontent.com/u/7255?v=4&s=40
   :commits: 2
   :href: https://github.com/svoop
   :name: svoop
-- :avatar_url: https://avatars3.githubusercontent.com/u/65746?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/65746?v=4&s=40
   :commits: 2
   :href: https://github.com/tdtds
   :name: tdtds
-- :avatar_url: https://avatars0.githubusercontent.com/u/26554?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/26554?v=4&s=40
   :commits: 2
   :href: https://github.com/tf
   :name: tf
-- :avatar_url: https://avatars3.githubusercontent.com/u/889632?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/889632?v=4&s=40
   :commits: 2
   :href: https://github.com/tiredpixel
   :name: tiredpixel
-- :avatar_url: https://avatars2.githubusercontent.com/u/20390?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/20390?v=4&s=40
   :commits: 2
   :href: https://github.com/tomlea
   :name: tomlea
-- :avatar_url: https://avatars0.githubusercontent.com/u/217126?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/217126?v=4&s=40
   :commits: 2
   :href: https://github.com/utkarshkukreti
   :name: utkarshkukreti
-- :avatar_url: https://avatars2.githubusercontent.com/u/203?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/203?v=4&s=40
   :commits: 2
   :href: https://github.com/wfarr
   :name: wfarr
-- :avatar_url: https://avatars0.githubusercontent.com/u/18807?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/18807?v=4&s=40
   :commits: 2
   :href: https://github.com/yaotti
   :name: yaotti
-- :avatar_url: https://avatars3.githubusercontent.com/u/86065?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/86065?v=4&s=40
   :commits: 2
   :href: https://github.com/YorickPeterse
   :name: YorickPeterse
-- :avatar_url: https://avatars2.githubusercontent.com/u/349796?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/349796?v=4&s=40
   :commits: 1
   :href: https://github.com/adilsoncarvalho
   :name: adilsoncarvalho
-- :avatar_url: https://avatars2.githubusercontent.com/u/19343?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/1303680?v=4&s=40
+  :commits: 1
+  :href: https://github.com/adrian-gomez
+  :name: adrian-gomez
+- :avatar_url: https://avatars1.githubusercontent.com/u/19343?v=4&s=40
   :commits: 1
   :href: https://github.com/ai
   :name: ai
-- :avatar_url: https://avatars1.githubusercontent.com/u/4295?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/4295?v=4&s=40
   :commits: 1
   :href: https://github.com/aitor
   :name: aitor
-- :avatar_url: https://avatars1.githubusercontent.com/u/87186?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/5289700?v=4&s=40
+  :commits: 1
+  :href: https://github.com/akhramov
+  :name: akhramov
+- :avatar_url: https://avatars2.githubusercontent.com/u/87186?v=4&s=40
   :commits: 1
   :href: https://github.com/aledalgrande
   :name: aledalgrande
-- :avatar_url: https://avatars0.githubusercontent.com/u/557414?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/557414?v=4&s=40
   :commits: 1
   :href: https://github.com/alepore
   :name: alepore
-- :avatar_url: https://avatars3.githubusercontent.com/u/505121?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/505121?v=4&s=40
   :commits: 1
   :href: https://github.com/AlexanderPavlenko
   :name: AlexanderPavlenko
-- :avatar_url: https://avatars1.githubusercontent.com/u/150174?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/150174?v=4&s=40
   :commits: 1
   :href: https://github.com/alup
   :name: alup
-- :avatar_url: https://avatars0.githubusercontent.com/u/2768870?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/2768870?v=4&s=40
   :commits: 1
   :href: https://github.com/alyssais
   :name: alyssais
-- :avatar_url: https://avatars2.githubusercontent.com/u/226707?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/226707?v=4&s=40
   :commits: 1
   :href: https://github.com/anibali
   :name: anibali
-- :avatar_url: https://avatars2.githubusercontent.com/u/7622?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/7622?v=4&s=40
   :commits: 1
   :href: https://github.com/antono
   :name: antono
-- :avatar_url: https://avatars3.githubusercontent.com/u/342081?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/342081?v=4&s=40
   :commits: 1
   :href: https://github.com/aprescott
   :name: aprescott
-- :avatar_url: https://avatars2.githubusercontent.com/u/11692?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/11692?v=4&s=40
   :commits: 1
   :href: https://github.com/apsoto
   :name: apsoto
-- :avatar_url: https://avatars0.githubusercontent.com/u/18344?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/18344?v=4&s=40
   :commits: 1
   :href: https://github.com/aptinio
   :name: aptinio
-- :avatar_url: https://avatars3.githubusercontent.com/u/428480?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/428480?v=4&s=40
   :commits: 1
   :href: https://github.com/ardavis
   :name: ardavis
-- :avatar_url: https://avatars2.githubusercontent.com/u/1913?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/1913?v=4&s=40
   :commits: 1
   :href: https://github.com/ariejan
   :name: ariejan
-- :avatar_url: https://avatars1.githubusercontent.com/u/3948?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/3948?v=4&s=40
   :commits: 1
   :href: https://github.com/arunagw
   :name: arunagw
-- :avatar_url: https://avatars2.githubusercontent.com/u/12306?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/553687?v=4&s=40
   :commits: 1
-  :href: https://github.com/auxesis
-  :name: auxesis
-- :avatar_url: https://avatars2.githubusercontent.com/u/1404325?v=3&s=40
+  :href: https://github.com/asehra
+  :name: asehra
+- :avatar_url: https://avatars1.githubusercontent.com/u/1404325?v=4&s=40
   :commits: 1
   :href: https://github.com/aycabta
   :name: aycabta
-- :avatar_url: https://avatars0.githubusercontent.com/u/2085622?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/2085622?v=4&s=40
   :commits: 1
   :href: https://github.com/backus
   :name: backus
-- :avatar_url: https://avatars1.githubusercontent.com/u/6197?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/6197?v=4&s=40
   :commits: 1
   :href: https://github.com/bak
   :name: bak
-- :avatar_url: https://avatars2.githubusercontent.com/u/4388676?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/4388676?v=4&s=40
   :commits: 1
   :href: https://github.com/Bartuz
   :name: Bartuz
-- :avatar_url: https://avatars1.githubusercontent.com/u/14111?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/14111?v=4&s=40
   :commits: 1
   :href: https://github.com/bdimcheff
   :name: bdimcheff
-- :avatar_url: https://avatars3.githubusercontent.com/u/7258489?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/7258489?v=4&s=40
   :commits: 1
   :href: https://github.com/bdshroyer
   :name: bdshroyer
-- :avatar_url: https://avatars3.githubusercontent.com/u/25421?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/25421?v=4&s=40
   :commits: 1
   :href: https://github.com/benhamill
   :name: benhamill
-- :avatar_url: https://avatars1.githubusercontent.com/u/712322?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/712322?v=4&s=40
   :commits: 1
   :href: https://github.com/benlakey
   :name: benlakey
-- :avatar_url: https://avatars1.githubusercontent.com/u/41963?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/41963?v=4&s=40
   :commits: 1
   :href: https://github.com/benlovell
   :name: benlovell
-- :avatar_url: https://avatars2.githubusercontent.com/u/239754?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/239754?v=4&s=40
   :commits: 1
   :href: https://github.com/benmoss
   :name: benmoss
-- :avatar_url: https://avatars3.githubusercontent.com/u/4595?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/4595?v=4&s=40
   :commits: 1
   :href: https://github.com/bensie
   :name: bensie
-- :avatar_url: https://avatars0.githubusercontent.com/u/2901?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/2901?v=4&s=40
   :commits: 1
   :href: https://github.com/bgreenlee
   :name: bgreenlee
-- :avatar_url: https://avatars3.githubusercontent.com/u/240676?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/240676?v=4&s=40
   :commits: 1
   :href: https://github.com/bison
   :name: bison
-- :avatar_url: https://avatars1.githubusercontent.com/u/56195?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/56195?v=4&s=40
   :commits: 1
   :href: https://github.com/bitboxer
   :name: bitboxer
-- :avatar_url: https://avatars2.githubusercontent.com/u/110023?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/110023?v=4&s=40
   :commits: 1
   :href: https://github.com/bjfish
   :name: bjfish
-- :avatar_url: https://avatars3.githubusercontent.com/u/173?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/173?v=4&s=40
   :commits: 1
   :href: https://github.com/bkeepers
   :name: bkeepers
-- :avatar_url: https://avatars2.githubusercontent.com/u/489331?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/489331?v=4&s=40
   :commits: 1
   :href: https://github.com/brandonblack
   :name: brandonblack
-- :avatar_url: https://avatars1.githubusercontent.com/u/459997?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/459997?v=4&s=40
   :commits: 1
   :href: https://github.com/BrianHawley
   :name: BrianHawley
-- :avatar_url: https://avatars2.githubusercontent.com/u/85?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/85?v=4&s=40
   :commits: 1
   :href: https://github.com/brixen
   :name: brixen
-- :avatar_url: https://avatars3.githubusercontent.com/u/18175?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/18175?v=4&s=40
   :commits: 1
   :href: https://github.com/bryanwoods
   :name: bryanwoods
-- :avatar_url: https://avatars1.githubusercontent.com/u/245096?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/245096?v=4&s=40
   :commits: 1
   :href: https://github.com/bwillis
   :name: bwillis
-- :avatar_url: https://avatars0.githubusercontent.com/u/4449?v=3&s=40
-  :commits: 1
-  :href: https://github.com/cainlevy
-  :name: cainlevy
-- :avatar_url: https://avatars1.githubusercontent.com/u/191320?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/191320?v=4&s=40
   :commits: 1
   :href: https://github.com/ccutrer
   :name: ccutrer
-- :avatar_url: https://avatars3.githubusercontent.com/u/27545?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/27545?v=4&s=40
   :commits: 1
   :href: https://github.com/cehoffman
   :name: cehoffman
-- :avatar_url: https://avatars3.githubusercontent.com/u/22738?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/22738?v=4&s=40
   :commits: 1
   :href: https://github.com/chief
   :name: chief
-- :avatar_url: https://avatars3.githubusercontent.com/u/1406220?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/1406220?v=4&s=40
   :commits: 1
   :href: https://github.com/christhekeele
   :name: christhekeele
-- :avatar_url: https://avatars3.githubusercontent.com/u/69235?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/69235?v=4&s=40
   :commits: 1
   :href: https://github.com/chulkilee
   :name: chulkilee
-- :avatar_url: https://avatars1.githubusercontent.com/u/727781?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/727781?v=4&s=40
   :commits: 1
   :href: https://github.com/cirdes
   :name: cirdes
-- :avatar_url: https://avatars2.githubusercontent.com/u/10076?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/10076?v=4&s=40
   :commits: 1
   :href: https://github.com/claudiob
   :name: claudiob
-- :avatar_url: https://avatars1.githubusercontent.com/u/6425580?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/6425580?v=4&s=40
   :commits: 1
   :href: https://github.com/Cohen-Carlisle
   :name: Cohen-Carlisle
-- :avatar_url: https://avatars2.githubusercontent.com/u/22284?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/22284?v=4&s=40
   :commits: 1
   :href: https://github.com/CoralineAda
   :name: CoralineAda
-- :avatar_url: https://avatars3.githubusercontent.com/u/815285?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/815285?v=4&s=40
   :commits: 1
   :href: https://github.com/d-reinhold
   :name: d-reinhold
-- :avatar_url: https://avatars3.githubusercontent.com/u/92105?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/92105?v=4&s=40
   :commits: 1
   :href: https://github.com/danfinnie
   :name: danfinnie
-- :avatar_url: https://avatars1.githubusercontent.com/u/1123601?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/1123601?v=4&s=40
   :commits: 1
   :href: https://github.com/dangoita
   :name: dangoita
-- :avatar_url: https://avatars2.githubusercontent.com/u/319081?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/319081?v=4&s=40
   :commits: 1
   :href: https://github.com/danielpclark
   :name: danielpclark
-- :avatar_url: https://avatars0.githubusercontent.com/u/36873?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/6856120?v=4&s=40
   :commits: 1
-  :href: https://github.com/davidcelis
-  :name: davidcelis
-- :avatar_url: https://avatars0.githubusercontent.com/u/466764?v=3&s=40
+  :href: https://github.com/daviddidntthink
+  :name: daviddidntthink
+- :avatar_url: https://avatars3.githubusercontent.com/u/466764?v=4&s=40
   :commits: 1
   :href: https://github.com/DavidEGrayson
   :name: DavidEGrayson
-- :avatar_url: https://avatars1.githubusercontent.com/u/2887858?v=3&s=40
-  :commits: 1
-  :href: https://github.com/deivid-rodriguez
-  :name: deivid-rodriguez
-- :avatar_url: https://avatars3.githubusercontent.com/u/152152?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/152152?v=4&s=40
   :commits: 1
   :href: https://github.com/derekprior
   :name: derekprior
-- :avatar_url: https://avatars3.githubusercontent.com/u/28270?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/28270?v=4&s=40
   :commits: 1
   :href: https://github.com/dholdren
   :name: dholdren
-- :avatar_url: https://avatars2.githubusercontent.com/u/2268?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/2268?v=4&s=40
   :commits: 1
   :href: https://github.com/djanowski
   :name: djanowski
-- :avatar_url: https://avatars3.githubusercontent.com/u/16464?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/16464?v=4&s=40
   :commits: 1
   :href: https://github.com/dkastner
   :name: dkastner
-- :avatar_url: https://avatars1.githubusercontent.com/u/7035?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/7035?v=4&s=40
   :commits: 1
   :href: https://github.com/dlee
   :name: dlee
-- :avatar_url: https://avatars3.githubusercontent.com/u/808253?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/808253?v=4&s=40
   :commits: 1
   :href: https://github.com/dmueller
   :name: dmueller
-- :avatar_url: https://avatars3.githubusercontent.com/u/482089?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/482089?v=4&s=40
   :commits: 1
   :href: https://github.com/domcleal
   :name: domcleal
-- :avatar_url: https://avatars0.githubusercontent.com/u/9831?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/9831?v=4&s=40
   :commits: 1
   :href: https://github.com/drbrain
   :name: drbrain
-- :avatar_url: https://avatars0.githubusercontent.com/u/2990?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/2990?v=4&s=40
   :commits: 1
   :href: https://github.com/dweinand
   :name: dweinand
-- :avatar_url: https://avatars0.githubusercontent.com/u/954402?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/118850?v=4&s=40
+  :commits: 1
+  :href: https://github.com/dwradcliffe
+  :name: dwradcliffe
+- :avatar_url: https://avatars3.githubusercontent.com/u/954402?v=4&s=40
   :commits: 1
   :href: https://github.com/dylanahsmith
   :name: dylanahsmith
-- :avatar_url: https://avatars1.githubusercontent.com/u/150197?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/150197?v=4&s=40
   :commits: 1
   :href: https://github.com/e2
   :name: e2
-- :avatar_url: https://avatars2.githubusercontent.com/u/1598?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/1598?v=4&s=40
   :commits: 1
   :href: https://github.com/ecoleman
   :name: ecoleman
-- :avatar_url: https://avatars3.githubusercontent.com/u/5291164?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/5291164?v=4&s=40
   :commits: 1
   :href: https://github.com/ejaypcanaria
   :name: ejaypcanaria
-- :avatar_url: https://avatars2.githubusercontent.com/u/173797?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/173797?v=4&s=40
   :commits: 1
   :href: https://github.com/eloyesp
   :name: eloyesp
-- :avatar_url: https://avatars2.githubusercontent.com/u/2344965?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/2344965?v=4&s=40
   :commits: 1
   :href: https://github.com/EmilRehnberg
   :name: EmilRehnberg
-- :avatar_url: https://avatars0.githubusercontent.com/u/11366?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/11366?v=4&s=40
   :commits: 1
   :href: https://github.com/epall
   :name: epall
-- :avatar_url: https://avatars3.githubusercontent.com/u/3483?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/28198?v=4&s=40
+  :commits: 1
+  :href: https://github.com/ericboehs
+  :name: ericboehs
+- :avatar_url: https://avatars0.githubusercontent.com/u/3483?v=4&s=40
   :commits: 1
   :href: https://github.com/farski
   :name: farski
-- :avatar_url: https://avatars3.githubusercontent.com/u/59880?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/59880?v=4&s=40
   :commits: 1
   :href: https://github.com/faun
   :name: faun
-- :avatar_url: https://avatars3.githubusercontent.com/u/74834?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/74834?v=4&s=40
   :commits: 1
   :href: https://github.com/Flameeyes
   :name: Flameeyes
-- :avatar_url: https://avatars1.githubusercontent.com/u/5892?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/5892?v=4&s=40
   :commits: 1
   :href: https://github.com/Fluxx
   :name: Fluxx
-- :avatar_url: https://avatars0.githubusercontent.com/u/247?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/247?v=4&s=40
   :commits: 1
   :href: https://github.com/francois
   :name: francois
-- :avatar_url: https://avatars3.githubusercontent.com/u/31945?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/31945?v=4&s=40
   :commits: 1
   :href: https://github.com/fredwu
   :name: fredwu
-- :avatar_url: https://avatars1.githubusercontent.com/u/1993787?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/1993787?v=4&s=40
   :commits: 1
   :href: https://github.com/fuadsaud
   :name: fuadsaud
-- :avatar_url: https://avatars2.githubusercontent.com/u/665150?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/665150?v=4&s=40
   :commits: 1
   :href: https://github.com/fvaleur
   :name: fvaleur
-- :avatar_url: https://avatars3.githubusercontent.com/u/4477761?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/4477761?v=4&s=40
   :commits: 1
   :href: https://github.com/gearnode
   :name: gearnode
-- :avatar_url: https://avatars0.githubusercontent.com/u/240650?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/240650?v=4&s=40
   :commits: 1
   :href: https://github.com/GeekOnCoffee
   :name: GeekOnCoffee
-- :avatar_url: https://avatars0.githubusercontent.com/u/222582?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/222582?v=4&s=40
   :commits: 1
   :href: https://github.com/gkop
   :name: gkop
-- :avatar_url: https://avatars1.githubusercontent.com/u/1210048?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/1210048?v=4&s=40
   :commits: 1
   :href: https://github.com/grddev
   :name: grddev
-- :avatar_url: https://avatars3.githubusercontent.com/u/604618?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/604618?v=4&s=40
   :commits: 1
   :href: https://github.com/gsamokovarov
   :name: gsamokovarov
-- :avatar_url: https://avatars3.githubusercontent.com/u/1107956?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/1107956?v=4&s=40
   :commits: 1
   :href: https://github.com/heliocola
   :name: heliocola
-- :avatar_url: https://avatars3.githubusercontent.com/u/216?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/216?v=4&s=40
   :commits: 1
   :href: https://github.com/henrik
   :name: henrik
-- :avatar_url: https://avatars3.githubusercontent.com/u/247402?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/247402?v=4&s=40
   :commits: 1
   :href: https://github.com/hiukkanen
   :name: hiukkanen
-- :avatar_url: https://avatars2.githubusercontent.com/u/532?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/532?v=4&s=40
   :commits: 1
   :href: https://github.com/hughbien
   :name: hughbien
-- :avatar_url: https://avatars0.githubusercontent.com/u/803765?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/803765?v=4&s=40
   :commits: 1
   :href: https://github.com/Intrepidd
   :name: Intrepidd
-- :avatar_url: https://avatars3.githubusercontent.com/u/331023?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/331023?v=4&s=40
   :commits: 1
   :href: https://github.com/invisiblefunnel
   :name: invisiblefunnel
-- :avatar_url: https://avatars0.githubusercontent.com/u/4662860?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/4662860?v=4&s=40
   :commits: 1
   :href: https://github.com/ivantsepp
   :name: ivantsepp
-- :avatar_url: https://avatars2.githubusercontent.com/u/57440?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/57440?v=4&s=40
   :commits: 1
   :href: https://github.com/IvanUkhov
   :name: IvanUkhov
-- :avatar_url: https://avatars1.githubusercontent.com/u/206662?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/206662?v=4&s=40
   :commits: 1
   :href: https://github.com/jacquescrocker
   :name: jacquescrocker
-- :avatar_url: https://avatars0.githubusercontent.com/u/1093?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/4100127?v=4&s=40
+  :commits: 1
+  :href: https://github.com/jakauppila
+  :name: jakauppila
+- :avatar_url: https://avatars3.githubusercontent.com/u/1093?v=4&s=40
   :commits: 1
   :href: https://github.com/jamie
   :name: jamie
-- :avatar_url: https://avatars3.githubusercontent.com/u/1903?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/1903?v=4&s=40
   :commits: 1
   :href: https://github.com/jamiew
   :name: jamiew
-- :avatar_url: https://avatars3.githubusercontent.com/u/191521?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/191521?v=4&s=40
   :commits: 1
   :href: https://github.com/jarl-dk
   :name: jarl-dk
-- :avatar_url: https://avatars1.githubusercontent.com/u/119972?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/119972?v=4&s=40
   :commits: 1
   :href: https://github.com/jasonkarns
   :name: jasonkarns
-- :avatar_url: https://avatars0.githubusercontent.com/u/50673?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/50673?v=4&s=40
   :commits: 1
   :href: https://github.com/jasonmp85
   :name: jasonmp85
-- :avatar_url: https://avatars0.githubusercontent.com/u/66090?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/66090?v=4&s=40
   :commits: 1
   :href: https://github.com/jayniz
   :name: jayniz
-- :avatar_url: https://avatars3.githubusercontent.com/u/6093002?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/6093002?v=4&s=40
   :commits: 1
   :href: https://github.com/jbodah
   :name: jbodah
-- :avatar_url: https://avatars2.githubusercontent.com/u/109489?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/109489?v=4&s=40
   :commits: 1
   :href: https://github.com/jenseng
   :name: jenseng
-- :avatar_url: https://avatars1.githubusercontent.com/u/98601?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/98601?v=4&s=40
   :commits: 1
   :href: https://github.com/jfirebaugh
   :name: jfirebaugh
-- :avatar_url: https://avatars2.githubusercontent.com/u/108205?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/108205?v=4&s=40
   :commits: 1
   :href: https://github.com/jgaskins
   :name: jgaskins
-- :avatar_url: https://avatars1.githubusercontent.com/u/141294?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/141294?v=4&s=40
   :commits: 1
   :href: https://github.com/jhass
   :name: jhass
-- :avatar_url: https://avatars2.githubusercontent.com/u/169064?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/169064?v=4&s=40
   :commits: 1
   :href: https://github.com/jingweno
   :name: jingweno
-- :avatar_url: https://avatars1.githubusercontent.com/u/6097?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/6097?v=4&s=40
   :commits: 1
   :href: https://github.com/jjb
   :name: jjb
-- :avatar_url: https://avatars0.githubusercontent.com/u/654882?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/654882?v=4&s=40
   :commits: 1
   :href: https://github.com/jkeiser
   :name: jkeiser
-- :avatar_url: https://avatars0.githubusercontent.com/u/6550267?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/6550267?v=4&s=40
   :commits: 1
   :href: https://github.com/JMorimoto
   :name: JMorimoto
-- :avatar_url: https://avatars0.githubusercontent.com/u/6078?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/6078?v=4&s=40
   :commits: 1
   :href: https://github.com/jmoses
   :name: jmoses
-- :avatar_url: https://avatars3.githubusercontent.com/u/949482?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/949482?v=4&s=40
   :commits: 1
   :href: https://github.com/joallard
   :name: joallard
-- :avatar_url: https://avatars1.githubusercontent.com/u/27818?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/27818?v=4&s=40
   :commits: 1
   :href: https://github.com/jstorimer
   :name: jstorimer
-- :avatar_url: https://avatars1.githubusercontent.com/u/75184?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/75184?v=4&s=40
   :commits: 1
   :href: https://github.com/jtarchie
   :name: jtarchie
-- :avatar_url: https://avatars2.githubusercontent.com/u/2160?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/9669739?v=4&s=40
   :commits: 1
-  :href: https://github.com/kakutani
-  :name: kakutani
-- :avatar_url: https://avatars2.githubusercontent.com/u/7998752?v=3&s=40
-  :commits: 1
-  :href: https://github.com/kevintpeng
-  :name: kevintpeng
-- :avatar_url: https://avatars2.githubusercontent.com/u/19684?v=3&s=40
-  :commits: 1
-  :href: https://github.com/kmayer
-  :name: kmayer
-- :avatar_url: https://avatars3.githubusercontent.com/u/19998?v=3&s=40
-  :commits: 1
-  :href: https://github.com/kml
-  :name: kml
-- :avatar_url: https://avatars0.githubusercontent.com/u/3286234?v=3&s=40
+  :href: https://github.com/jumbosushi
+  :name: jumbosushi
+- :avatar_url: https://avatars3.githubusercontent.com/u/3286234?v=4&s=40
   :commits: 1
   :href: https://github.com/kodnin
   :name: kodnin
-- :avatar_url: https://avatars0.githubusercontent.com/u/13203?v=3&s=40
-  :commits: 1
-  :href: https://github.com/koic
-  :name: koic
-- :avatar_url: https://avatars0.githubusercontent.com/u/6856120?v=3&s=40
-  :commits: 1
-  :href: https://github.com/kotoshenya
-  :name: kotoshenya
-- :avatar_url: https://avatars1.githubusercontent.com/u/869950?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/869950?v=4&s=40
   :commits: 1
   :href: https://github.com/KrauseFx
   :name: KrauseFx
-- :avatar_url: https://avatars3.githubusercontent.com/u/150485?v=3&s=40
-  :commits: 1
-  :href: https://github.com/krekoten
-  :name: krekoten
-- :avatar_url: https://avatars3.githubusercontent.com/u/37980?v=3&s=40
-  :commits: 1
-  :href: https://github.com/kyleshank
-  :name: kyleshank
-- :avatar_url: https://avatars2.githubusercontent.com/u/276834?v=3&s=40
-  :commits: 1
-  :href: https://github.com/kytrinyx
-  :name: kytrinyx
-- :avatar_url: https://avatars0.githubusercontent.com/u/88450?v=3&s=40
-  :commits: 1
-  :href: https://github.com/leobessa
-  :name: leobessa
-- :avatar_url: https://avatars3.githubusercontent.com/u/19248?v=3&s=40
-  :commits: 1
-  :href: https://github.com/lgierth
-  :name: lgierth
-- :avatar_url: https://avatars2.githubusercontent.com/u/101878?v=3&s=40
-  :commits: 1
-  :href: https://github.com/luismreis
-  :name: luismreis
-- :avatar_url: https://avatars2.githubusercontent.com/u/11562?v=3&s=40
-  :commits: 1
-  :href: https://github.com/lukaszx0
-  :name: lukaszx0
-- :avatar_url: https://avatars2.githubusercontent.com/u/11248?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/11248?v=4&s=40
   :commits: 1
   :href: https://github.com/Lytol
   :name: Lytol
-- :avatar_url: https://avatars0.githubusercontent.com/u/134304?v=3&s=40
-  :commits: 1
-  :href: https://github.com/MasterLambaster
-  :name: MasterLambaster
-- :avatar_url: https://avatars2.githubusercontent.com/u/113?v=3&s=40
-  :commits: 1
-  :href: https://github.com/mattetti
-  :name: mattetti
-- :avatar_url: https://avatars2.githubusercontent.com/u/1034?v=3&s=40
-  :commits: 1
-  :href: https://github.com/matthewd
-  :name: matthewd
-- :avatar_url: https://avatars1.githubusercontent.com/u/19260?v=3&s=40
-  :commits: 1
-  :href: https://github.com/mattwynne
-  :name: mattwynne
-- :avatar_url: https://avatars3.githubusercontent.com/u/22273?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/22273?v=4&s=40
   :commits: 1
   :href: https://github.com/mephux
   :name: mephux
-- :avatar_url: https://avatars2.githubusercontent.com/u/35058?v=3&s=40
-  :commits: 1
-  :href: https://github.com/mkristian
-  :name: mkristian
-- :avatar_url: https://avatars3.githubusercontent.com/u/167670?v=3&s=40
-  :commits: 1
-  :href: https://github.com/mtylty
-  :name: mtylty
-- :avatar_url: https://avatars1.githubusercontent.com/u/655165?v=3&s=40
-  :commits: 1
-  :href: https://github.com/mwrock
-  :name: mwrock
-- :avatar_url: https://avatars3.githubusercontent.com/u/764865?v=3&s=40
-  :commits: 1
-  :href: https://github.com/myersjustinc
-  :name: myersjustinc
-- :avatar_url: https://avatars1.githubusercontent.com/u/3279?v=3&s=40
-  :commits: 1
-  :href: https://github.com/nextmat
-  :name: nextmat
-- :avatar_url: https://avatars0.githubusercontent.com/u/829178?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/829178?v=4&s=40
   :commits: 1
   :href: https://github.com/nodo
   :name: nodo
-- :avatar_url: https://avatars0.githubusercontent.com/u/2767?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/2767?v=4&s=40
   :commits: 1
   :href: https://github.com/nono
   :name: nono
-- :avatar_url: https://avatars0.githubusercontent.com/u/1260687?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/1260687?v=4&s=40
   :commits: 1
   :href: https://github.com/obfusk
   :name: obfusk
-- :avatar_url: https://avatars3.githubusercontent.com/u/13812?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/13812?v=4&s=40
   :commits: 1
   :href: https://github.com/perplexes
   :name: perplexes
-- :avatar_url: https://avatars3.githubusercontent.com/u/6321?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/6321?v=4&s=40
   :commits: 1
   :href: https://github.com/pixeltrix
   :name: pixeltrix
-- :avatar_url: https://avatars1.githubusercontent.com/u/69933?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/69933?v=4&s=40
   :commits: 1
   :href: https://github.com/Ptico
   :name: Ptico
-- :avatar_url: https://avatars0.githubusercontent.com/u/46677?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/46677?v=4&s=40
   :commits: 1
   :href: https://github.com/r00k
   :name: r00k
-- :avatar_url: https://avatars2.githubusercontent.com/u/617897?v=3&s=40
-  :commits: 1
-  :href: https://github.com/radsaq
-  :name: radsaq
-- :avatar_url: https://avatars2.githubusercontent.com/u/1033740?v=3&s=40
-  :commits: 1
-  :href: https://github.com/rhenium
-  :name: rhenium
-- :avatar_url: https://avatars1.githubusercontent.com/u/30442?v=3&s=40
-  :commits: 1
-  :href: https://github.com/rkh
-  :name: rkh
-- :avatar_url: https://avatars1.githubusercontent.com/u/2394703?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/2394703?v=4&s=40
   :commits: 1
   :href: https://github.com/seuros
   :name: seuros
-- :avatar_url: https://avatars2.githubusercontent.com/u/649130?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/649130?v=4&s=40
   :commits: 1
   :href: https://github.com/skateman
   :name: skateman
-- :avatar_url: https://avatars3.githubusercontent.com/u/1078126?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/916368?v=4&s=40
+  :commits: 1
+  :href: https://github.com/slimeate
+  :name: slimeate
+- :avatar_url: https://avatars0.githubusercontent.com/u/1078126?v=4&s=40
   :commits: 1
   :href: https://github.com/suzukaze
   :name: suzukaze
-- :avatar_url: https://avatars1.githubusercontent.com/u/159?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/159?v=4&s=40
   :commits: 1
   :href: https://github.com/technicalpickles
   :name: technicalpickles
-- :avatar_url: https://avatars0.githubusercontent.com/u/270746?v=3&s=40
+- :avatar_url: https://avatars3.githubusercontent.com/u/270746?v=4&s=40
   :commits: 1
   :href: https://github.com/thejonanshow
   :name: thejonanshow
-- :avatar_url: https://avatars1.githubusercontent.com/u/2567?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/2567?v=4&s=40
   :commits: 1
   :href: https://github.com/tmm1
   :name: tmm1
-- :avatar_url: https://avatars3.githubusercontent.com/u/59220?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/59220?v=4&s=40
   :commits: 1
   :href: https://github.com/tundal45
   :name: tundal45
-- :avatar_url: https://avatars1.githubusercontent.com/u/6173?v=3&s=40
-  :commits: 1
-  :href: https://github.com/vinbarnes
-  :name: vinbarnes
-- :avatar_url: https://avatars1.githubusercontent.com/u/8132?v=3&s=40
+- :avatar_url: https://avatars2.githubusercontent.com/u/8132?v=4&s=40
   :commits: 1
   :href: https://github.com/yob
   :name: yob
-- :avatar_url: https://avatars3.githubusercontent.com/u/853977?v=3&s=40
+- :avatar_url: https://avatars0.githubusercontent.com/u/853977?v=4&s=40
   :commits: 1
   :href: https://github.com/yous
   :name: yous
-- :avatar_url: https://avatars2.githubusercontent.com/u/1037?v=3&s=40
+- :avatar_url: https://avatars1.githubusercontent.com/u/1037?v=4&s=40
   :commits: 1
   :href: https://github.com/zmack
   :name: zmack

--- a/lib/tasks/man_generator/man.rake
+++ b/lib/tasks/man_generator/man.rake
@@ -8,6 +8,7 @@ task :man => [:update_vendor] do
     mkdir_p "source/#{version}/man"
 
     Dir.chdir "vendor/bundler" do
+      sh("bin/rake", "index.txt") { } # it's OK if this fails, as it means there was no index.txt file
       sh "git reset --hard HEAD"
       sh "git checkout origin/#{branch}"
       sh "#{Gem.ruby} -S bundle exec ronn -5 man/*.ronn"


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was the `.ronn` files need `index.txt` to be present to properly link things.

Closes https://github.com/bundler/bundler/pull/6143

### What was your diagnosis of the problem?

My diagnosis was we needed to build `index.txt` for 1.16+