### PR TITLE
Edit out require directive for rack/cache in docs

### DIFF
--- a/source/v1.12/bundler_setup.html.md
+++ b/source/v1.12/bundler_setup.html.md
@@ -72,20 +72,7 @@ require 'rack-cache'
 require 'nokogiri'
 ~~~
 
-Astute readers will notice that the correct way to require the <code>rack-cache</code>
-gem is <code>require 'rack/cache'</code>, not <code>require 'rack-cache'</code>. To tell
-bundler to use <code>require 'rack/cache'</code>, update your Gemfile:
-
-~~~ ruby
-source 'https://rubygems.org'
-
-gem 'rails', '3.0.0.rc'
-gem 'rack-cache', :require => 'rack/cache'
-gem 'nokogiri', '~> 1.4.2'
-~~~
-
 For such a small <code>Gemfile</code>, we'd advise you to skip
-<code>Bundler.require</code> and just require the gems by hand (especially given the
-need to put in a <code>:require</code> directive in the <code>Gemfile</code>). For much
+<code>Bundler.require</code> and just require the gems by hand. For much
 larger <code>Gemfile</code>s, using <code>Bundler.require</code> allows you to skip
 repeating a large stack of requirements.

--- a/source/v1.16/rationale.html.haml
+++ b/source/v1.16/rationale.html.haml
@@ -136,22 +136,8 @@
       require 'nokogiri'
 
     %p
-      Astute readers will notice that the correct way to require the <code>rack-cache</code>
-      gem is <code>require 'rack/cache'</code>, not <code>require 'rack-cache'</code>. To tell
-      bundler to use <code>require 'rack/cache'</code>, update your Gemfile:
-
-    :code
-      # lang: ruby
-      source 'https://rubygems.org'
-
-      gem 'rails', '4.1.0.rc2'
-      gem 'rack-cache', require: 'rack/cache'
-      gem 'nokogiri', '~> 1.6.1'
-
-    %p
       For such a small <code>Gemfile</code>, we'd advise you to skip
-      <code>Bundler.require</code> and just require the gems by hand (especially given the
-      need to put in a <code>:require</code> directive in the <code>Gemfile</code>). For much
+      <code>Bundler.require</code> and just require the gems by hand. For much
       larger <code>Gemfile</code>s, using <code>Bundler.require</code> allows you to skip
       repeating a large stack of requirements.
 


### PR DESCRIPTION

Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was...
- There were some outdated references in the Bundler rationale and setup guide docs that referred to how to use the require directive for `rack/cache`.
### What was your diagnosis of the problem?

My diagnosis was...
- After reading the discussion on https://github.com/bundler/bundler-site/issues/130, I edited out the require directive for `rack/cache`since it's not needed anymore.

### What is your fix for the problem, implemented in this PR?

My fix...
- Edit out outdated documentation.
### Why did you choose this fix out of the possible options?

I chose this fix because...
- it's what was discussed in issue https://github.com/bundler/bundler-site/issues/130