### PR TITLE
update bash shebang to '/usr/bin/env bash' form

### DIFF
--- a/source/v1.12/git_bisect.html.md
+++ b/source/v1.12/git_bisect.html.md
@@ -19,7 +19,7 @@ to test if they are not reset.
 Here's a minimal example script that runs the rake task `spec`:
 
 ~~~ bash
-#!/bin/bash
+#!/usr/bin/env bash
 bundle install
 bin/rake spec
 status=$?

--- a/source/v1.13/git_bisect.html.md
+++ b/source/v1.13/git_bisect.html.md
@@ -19,7 +19,7 @@ to test if they are not reset.
 Here's a minimal example script that runs the rake task `spec`:
 
 ~~~ bash
-#!/bin/bash
+#!/usr/bin/env bash
 bundle install
 bin/rake spec
 status=$?

--- a/source/v1.14/git_bisect.html.md
+++ b/source/v1.14/git_bisect.html.md
@@ -25,7 +25,7 @@ to test if they are not reset.
 Here's a minimal example script that runs the rake task `spec`:
 
 ~~~ bash
-#!/bin/bash
+#!/usr/bin/env bash
 bundle install
 bin/rake spec
 status=$?

--- a/source/v1.15/guides/git_bisect.html.md
+++ b/source/v1.15/guides/git_bisect.html.md
@@ -25,7 +25,7 @@ to test if they are not reset.
 Here's a minimal example script that runs the rake task `spec`:
 
 ~~~ bash
-#!/bin/bash
+#!/usr/bin/env bash
 bundle install
 bin/rake spec
 status=$?

--- a/source/v1.16/guides/git_bisect.html.md
+++ b/source/v1.16/guides/git_bisect.html.md
@@ -25,7 +25,7 @@ to test if they are not reset.
 Here's a minimal example script that runs the rake task `spec`:
 
 ~~~ bash
-#!/bin/bash
+#!/usr/bin/env bash
 bundle install
 bin/rake spec
 status=$?


### PR DESCRIPTION
/bin/bash can be misleading for instance on macs using `brew install bash` and rvm, since it will point to the factory bash.

In general, scripts are considered more portable using  the shebang with `!#/usr/bin/env bash`.

More info: https://stackoverflow.com/questions/21612980/why-is-usr-bin-env-bash-superior-to-bin-bash

May I also note that this ** PR is now consistent with all other script files in the repository** 👍 (I am a big fan of consistency)
