### PR TITLE
Add homepage action buttons

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -8,7 +8,9 @@ en:
       Bundler is an exit from dependency hell, and ensures that the gems
       you need are present in development, staging, and production.
       Starting work on a project is as simple as <code>bundle install</code>.
-    how_bundler_work_button: How Does Bundler Work?
+    what_can_bundler_do: What Can Bundler Do?
+    cli_docs: CLI Docs
+    chat_with_us: Chat With Us
     getting_started: Getting Started
     getting_started_description: |
       Getting started with bundler is easy! Open a terminal window and run this command:

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -8,7 +8,6 @@ es:
       Bundler es un éxito del infierno de dependencias, y asegura que las gemas
       usted necesita estén presente en entorno de desarollo, staging, y entorno de producción.
       Empezando trabajar en un proyecto es tan simple como <code>bundle install</code>.
-    how_bundler_work_button: ¿Cómo funciona Bundler?
     getting_started: Para empezar
     getting_started_description: |
       ¡Empezando con bundler es fácil! Abre una ventana del terminal y ejecuta este comando:

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -8,7 +8,6 @@ pl:
       Bundler pomaga wydostać się z piekła zależności i zapewnia, że gem'y które
       potrzebujesz są w Twoich środowiskach.
       Dzięki temu rozpoczęcie pracy nad projektem to wpisanie <code>bundle install</code> w konsoli.
-    how_bundler_work_button: Jak bundler działa?
     getting_started: Jak rozpocząć?
     getting_started_description: |
       Rozpoczęcie pracy z bundler'em jest bardzo proste! Otwórz terminal i uruchom tą komendę:

--- a/source/localizable/index.html.haml
+++ b/source/localizable/index.html.haml
@@ -51,6 +51,21 @@
             $ git add Gemfile Gemfile.lock
           %p.center-on-xs
             = link_to t('home.learn_more_bundle_install'), "./#{current_version}/man/bundle-install.1.html", class: 'btn btn-primary btn-lg pull-right btn-responsive'
+
+.row
+  .container
+    .col-md-12
+      %h2#get-involved Get involved
+      .large-font
+        Bundler has a lot of contributors and users, and we would love to have your help! If you have questions, join #{link_to 'the Bundler Slack', 'http://slack.bundler.io'} and we'll try to answer them. If you're interested in contributing (no programming skills needed), start with #{link_to 'the contributing guide', 'https://github.com/bundler/bundler/blob/master/doc/contributing/README.md'}. While participating in the Bundler project, please keep the #{link_to 'code of conduct', '/conduct.html'} in mind, and be inclusive and friendly towards everyone. If you have sponsorship or security questions, please contact the core team directly.
+
+      .contents
+        .buttons
+          = link_to 'Code of Conduct', '/conduct.html', class: 'btn btn-primary'
+          = link_to 'Join the Bundler Slack', 'http://slack.bundler.io', class: 'btn btn-primary'
+          = link_to 'Contributing guide', 'https://github.com/bundler/bundler/blob/master/doc/contributing/README.md', class: 'btn btn-primary'
+          = link_to 'Email the core team', 'mailto:team@bundler.io', class: 'btn btn-primary'
+
 :css
   .main-wrapper {
     padding-bottom: 0;

--- a/source/localizable/index.html.haml
+++ b/source/localizable/index.html.haml
@@ -14,7 +14,9 @@
 
       %p.text-center
         = link_to t("home.whats_new"), '/whats_new.html', class: 'btn btn-primary btn-lg btn-responsive'
-        = link_to t('home.how_bundler_work_button'), "./#{current_version}/#getting-started", class: 'btn btn-primary btn-lg btn-responsive'
+        = link_to t('home.what_can_bundler_do'), "./#{current_version}/#getting-started", class: 'btn btn-primary btn-lg btn-responsive'
+        = link_to t('home.cli_docs'), './man/bundle-install.1.html', class: 'btn btn-primary btn-lg btn-responsive'
+        = link_to t('home.chat_with_us'), 'http://slack.bundler.io', class: 'btn btn-primary btn-lg btn-responsive'
 
 .row.bg-light-blue
   .container


### PR DESCRIPTION
I realized the homepage didn't have a prominent link to the reference docs, so I added one. I also added a prominent link to join the Slack, as well as restoring the final paragraph of the old homepage with a call for readers to get involved and contribute.