### PR TITLE
Rewrote page headers for most v.16 guides and added subcopy to Docs…

### DIFF
--- a/source/v1.16/docs.html.haml
+++ b/source/v1.16/docs.html.haml
@@ -11,13 +11,17 @@
     .col-sm-5.col-sm-offset-0.col-xs-9.col-xs-offset-2
       %h3
         %b Guides
+      %p
+        Step-by-step tutorials that include useful explanations and and detailed instructions to help you get up and running.
       %ul.ul-padding
         - guides.each do |guide|
           %li= link_to_guide guide
 
     .col-sm-4.col-sm-offset-0.col-xs-9.col-xs-offset-2
       %h3
-        %b Reference
+        %b Reference Guides
+      %p
+        In-depth articles with information on each primary command and utility, and how to use them.
       %h4
         %b Primary Commands
       %ul.ul-padding

--- a/source/v1.16/guides/bundler_setup.html.haml
+++ b/source/v1.16/guides/bundler_setup.html.haml
@@ -1,5 +1,5 @@
 ---
-title: Using Bundler with plain Ruby
+title: How to use Bundler with Ruby
 ---
 .container.guide
   %h2 Bundler.setup

--- a/source/v1.16/guides/bundler_sharing.html.haml
+++ b/source/v1.16/guides/bundler_sharing.html.haml
@@ -1,9 +1,9 @@
 ---
-title: Sharing your code
+title: How to package and share code using Gemfile
 ---
 .container.guide
   %h2#sharing
-    Sharing your code
+    How to package and share code using Gemfile
   .contents
     .bullet
       .description

--- a/source/v1.16/guides/bundler_sharing.html.haml
+++ b/source/v1.16/guides/bundler_sharing.html.haml
@@ -1,9 +1,9 @@
 ---
-title: How to package and share code using Gemfile
+title: How to package and share code using a Gemfile
 ---
 .container.guide
   %h2#sharing
-    How to package and share code using Gemfile
+    How to package and share code using a Gemfile
   .contents
     .bullet
       .description

--- a/source/v1.16/guides/deploying.html.haml
+++ b/source/v1.16/guides/deploying.html.haml
@@ -1,8 +1,8 @@
 ---
-title: Deploying with Bundler
+title: How to deploy bundled applications
 ---
 .container.guide
-  %h2 Deploying bundled applications
+  %h2 How to deploy bundled applications
   .contents
     .bullet
       .description

--- a/source/v1.16/guides/git.html.haml
+++ b/source/v1.16/guides/git.html.haml
@@ -1,8 +1,8 @@
 ---
-title: Gems from git repositories
+title: How to install gems from git repositories
 ---
 .container.guide
-  %h2 Gems from git repositories
+  %h2 How to install gems from git repositories
 
   .contents
     .bullet

--- a/source/v1.16/guides/git_bisect.html.md
+++ b/source/v1.16/guides/git_bisect.html.md
@@ -1,5 +1,5 @@
 ---
-title: How to git bisect in projects using Bundler
+title: How to use git bisect with Bundler
 ---
 
 ## How to use git bisect

--- a/source/v1.16/guides/groups.html.haml
+++ b/source/v1.16/guides/groups.html.haml
@@ -1,8 +1,8 @@
 ---
-title: "Managing groups of gems"
+title: How to manage groups of gems
 ---
 .container.guide
-  %h2 Using Groups
+  %h2 How to manage groups of gems
 
   .contents
     .bullet

--- a/source/v1.16/guides/rails.html.haml
+++ b/source/v1.16/guides/rails.html.haml
@@ -1,11 +1,11 @@
 ---
-title: Using Bundler with Rails
+title: How to use Bundler with Rails
 ---
 .container.guide
   #intro
     Rails comes with baked in support with bundler.
 
-  %h2 Using Bundler with Rails
+  %h2 How to use Bundler with Rails
 
   .contents
     .bullet

--- a/source/v1.16/guides/rubygems_tls_ssl_troubleshooting_guide.html.md
+++ b/source/v1.16/guides/rubygems_tls_ssl_troubleshooting_guide.html.md
@@ -1,8 +1,8 @@
 ---
-title: RubyGems.org SSL Troubleshooting Guide
+title: How to troubleshoot RubyGems and Bundler TLS/SSL Issues
 ---
 
-# RubyGems.org SSL Troubleshooting Guide
+# How to troubleshoot RubyGems and Bundler TLS/SSL Issues
 
 If you’ve experienced issues related to SSL certificates and/or TLS versions, you’ve come
 to the right place. In this guide, we’ll explain how both of those issues come about and how

--- a/source/v1.16/guides/sinatra.html.haml
+++ b/source/v1.16/guides/sinatra.html.haml
@@ -1,8 +1,8 @@
 ---
-title: Using Bundler with Sinatra
+title: How to use Bundler with Sinatra
 ---
 .container.guide
-  %h2 Using Bundler with Sinatra
+  %h2 How to use Bundler with Sinatra
 
   .contents
     .bullet

--- a/source/v1.16/guides/updating_gems.html.haml
+++ b/source/v1.16/guides/updating_gems.html.haml
@@ -1,8 +1,8 @@
 ---
-title: Updating Gems
+title: How to update gems with Bundler
 ---
 .container.guide
-  %h2 Updating Gems
+  %h2 How to update gems with Bundler
   .contents
     .bullet
       .description

--- a/source/v1.16/rubymotion.html.haml
+++ b/source/v1.16/rubymotion.html.haml
@@ -1,5 +1,5 @@
 .container.guide
-  %h2 Using Bundler with RubyMotion
+  %h2 How to use Bundler with RubyMotion
   .contents
     .bullet
       .description


### PR DESCRIPTION
… main headers.

Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

Given that the Bundler Docs site receives so much direct traffic, I wanted to try to add some sub-copy on the main Docs landing page to give more context around the types of content a user could find. Additionally, I wanted to standardize (most) of the Guide titles to make them easier to find when a user does a search for the issue.

### What was your diagnosis of the problem?

To add two blurbs on the Docs main site, and to rewrite the titles of the v1.16 guides.

### What is your fix for the problem, implemented in this PR?

You can view the changes here:

- Docs landing page before the rewrite (what it currently looks like): 
![](https://photos-1.dropbox.com/t/2/AACjmxISW5HbiNJ9JNVTlktaPpCXnHA_8gZojCH-ByrU3A/12/643604378/png/32x32/3/1517288400/0/2/Docs_Page_Before.png/EIqN-5wFGDEgAigC/rV2QjGKM8WQKceBARn3grI274GKbBA-JnGMNLGocIFo?dl=0&preserve_transparency=1&size=2048x1536&size_mode=3)
- Docs landing page after the rewrite (notice the two blurbs under "Guides" and "Commands", as well as the revised Guide titles): 
![](https://photos-5.dropbox.com/t/2/AAAxlO1b4B_FvbfTAhyboZ64WRNnl6MIcWdsiIe8Y9MhFA/12/643604378/png/32x32/3/1517288400/0/2/Docs_Page_After.png/EIqN-5wFGDEgAigC/wRskybYxx7Xh_Cw0BM3LyqU-G4ObScLFM3z_ozKHnoQ?dl=0&preserve_transparency=1&size=2048x1536&size_mode=3)

### Why did you choose this fix out of the possible options?

I chose this fix because it's a quick fix and one that can translate into more Bundler users finding docs easier!
