### PR TITLE
Updated titles for three guides

### DIFF
--- a/source/localizable/v1.16/guides/creating_gem.en.html.md
+++ b/source/localizable/v1.16/guides/creating_gem.en.html.md
@@ -1,8 +1,8 @@
 ---
-title: Developing a RubyGem using Bundler
+title: How to create a Ruby gem with Bundler
 ---
 
-# Developing a RubyGem using Bundler
+# How to create a Ruby gem with Bundler
 
 Bundler is a tool created by Carl Lerche, Yehuda Katz, André Arko and various superb contributors 
 for managing Rubygems dependencies in Ruby libraries. Bundler 1.0 was released around the same 

--- a/source/localizable/v1.16/guides/using_bundler_in_applications.en.html.md
+++ b/source/localizable/v1.16/guides/using_bundler_in_applications.en.html.md
@@ -1,8 +1,8 @@
 ---
-title: Using Bundler In Applications
+title: How to manage application dependencies with Bundler
 ---
 
-# Using Bundler In Applications
+# How to manage application dependencies with Bundler
 
 This guide is originally written for Bundler v1.12. If you are using different version keep in mind that output can differ.
 To check Bundler version simply run `bundle -v`.

--- a/source/v1.16/guides/bundler_setup.html.haml
+++ b/source/v1.16/guides/bundler_setup.html.haml
@@ -2,7 +2,7 @@
 title: How to use Bundler with Ruby
 ---
 .container.guide
-  %h2 Bundler.setup
+  %h2 How to use Bundler with Ruby
 
   .contents
     .bullet


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was inconsistency in formatting titles. These three guides were accidentally left out from the updates made in PR https://github.com/bundler/bundler-site/pull/360

### What was your diagnosis of the problem?

My diagnosis was to fix headers for the guides on creating a Ruby gem, managing app dependencies, and the using Bundler with Ruby guides.

### What is your fix for the problem, implemented in this PR?

My fix was to edit the titles as follows:

1. **Developing a RubyGem using Bundler** is now **How to create a Ruby gem with Bundler**
2. **Using Bundler in Applications** is now **How to manage application dependencies with Bundler**
3. Swapped out **Bundler.setup** with **How to use Bundler with Ruby** at the top of the page.
 
### Why did you choose this fix out of the possible options?

I chose this fix because it was quick and easy to implement, and ensures consistency across v1.16 doc titles :)