### PR TITLE
Reword syntax section

### DIFF
--- a/source/localizable/v1.16/guides/using_bundler_in_applications.en.html.md
+++ b/source/localizable/v1.16/guides/using_bundler_in_applications.en.html.md
@@ -121,7 +121,7 @@ gem "nokogiri", ">= 1.4.2"
 
 Learn more about gems in Gemfile [here](/man/gemfile.5.html#GEMS).
 
-### More About Gemfile Syntax
+### Gemfile Syntax
 
 To learn more about Gemfile syntax click [here](/man/gemfile.5.html#SYNTAX).
 

--- a/source/localizable/v1.16/guides/using_bundler_in_applications.en.html.md
+++ b/source/localizable/v1.16/guides/using_bundler_in_applications.en.html.md
@@ -123,7 +123,7 @@ Learn more about gems in Gemfile [here](/man/gemfile.5.html#GEMS).
 
 ### More About Gemfile Syntax
 
-To learn more about Gemfile's click [here](/man/gemfile.5.html).
+To learn more about Gemfile's click [here](/man/gemfile.5.html#SYNTAX).
 
 ## Installing Gems - **bundle install**
 

--- a/source/localizable/v1.16/guides/using_bundler_in_applications.en.html.md
+++ b/source/localizable/v1.16/guides/using_bundler_in_applications.en.html.md
@@ -13,7 +13,7 @@ To check Bundler version simply run `bundle -v`.
 1. [Editing Gemfile](#editing-gemfile)
     1. [Sources](#sources)
     1. [Adding Gems](#adding-gems)
-    1. [More About Gemfile Syntax](#more-about-gemfile-syntax)
+    1. [Gemfile Syntax](#gemfile-syntax)
 1. [Installing Gems - **bundle install**](#installing-gems---bundle-install)
     1. [Development](#development)
     1. [Deployment](#deployment)

--- a/source/localizable/v1.16/guides/using_bundler_in_applications.en.html.md
+++ b/source/localizable/v1.16/guides/using_bundler_in_applications.en.html.md
@@ -123,7 +123,7 @@ Learn more about gems in Gemfile [here](/man/gemfile.5.html#GEMS).
 
 ### Gemfile Syntax
 
-To learn more about Gemfile syntax click [here](/man/gemfile.5.html#SYNTAX).
+Learn more about Gemfile syntax from the [gemfile manpage](/man/gemfile.5.html#SYNTAX).
 
 ## Installing Gems - **bundle install**
 

--- a/source/localizable/v1.16/guides/using_bundler_in_applications.en.html.md
+++ b/source/localizable/v1.16/guides/using_bundler_in_applications.en.html.md
@@ -123,7 +123,7 @@ Learn more about gems in Gemfile [here](/man/gemfile.5.html#GEMS).
 
 ### More About Gemfile Syntax
 
-To learn more about Gemfile's click [here](/man/gemfile.5.html#SYNTAX).
+To learn more about Gemfile syntax click [here](/man/gemfile.5.html#SYNTAX).
 
 ## Installing Gems - **bundle install**
 


### PR DESCRIPTION
### Problem:

The text:

> ### More About Gemfile Syntax
>
> To learn more about Gemfile's click [here](/man/gemfile.5.html).

* Is not grammatically correct.
* Is incomplete. (Gemfile's what?)
* Did not link directly to the relevant "syntax" section of the manpage.
* Had unhelpful link text "here"
* Gemfile syntax has not been previously discussed so "More About" heading is inaccurate.

### Fix: 

This PR updates the text to rectify these issues.
