### PR TITLE
Fix 404 to guides/git

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Begin by cloning the repository onto your location machine:
 
     git clone https://github.com/bundler/bundler-site.git
 
-Once complete repare the dependencies by running:
+Once complete prepare the dependencies by running:
 
     bundle install
 

--- a/source/v1.16/gemfile.html.haml
+++ b/source/v1.16/gemfile.html.haml
@@ -111,7 +111,7 @@
         will create a simple one, without any dependencies, executables or C extensions.
         This may work for simple gems, but not work for others. If there is no .gemspec,
         you probably shouldn't use the gem from git.
-      = link_to 'Learn more: Git', './git.html', class: 'btn btn-primary'
+      = link_to 'Learn more: Git', './guides/git.html', class: 'btn btn-primary'
 
     .bullet
       .description


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

When on the gemfile page, there is a link to learn more on using gems hosted via git. When clicked
I received a 404

### What was your diagnosis of the problem?

The relative link reference was missing the `guide` in the path

### What is your fix for the problem, implemented in this PR?

I updated the link, and fixed one other small typo.


