### PR TITLE
Document git :glob option for installing gems from subdirectories

### DIFF
--- a/source/v1.16/guides/git.html.haml
+++ b/source/v1.16/guides/git.html.haml
@@ -33,6 +33,14 @@ title: How to install gems from git repositories
         gem 'nokogiri', '1.7.0.1', :git => 'https://github.com/sparklemotion/nokogiri'
     .bullet
       .description
+        If the gem is located within a subdirectory of
+        a git repository, you can use the <code>:glob</code> option
+        to specify the location of its .gemspec
+      :code
+        # lang: ruby
+        gem 'cf-copilot', :git => 'https://github.com/cloudfoundry/copilot', :glob => 'sdk/ruby/*.gemspec'
+    .bullet
+      .description
         Specify that a git repository containing
         multiple .gemspec files should be treated
         as a gem source


### PR DESCRIPTION
### What was the end-user problem that led to this PR?
I initially logged Issue #372 for this, so just copying what part of what I said in there:

> Recently I needed to install a gem from a Git repository, but the gem was nested within a subdirectory of the repository. Looking at the [existing docs](http://bundler.io/guides/git.html) I couldn't find anything that would allow me to do this. I eventually found an issue that mentioned the `glob` parameter and it worked, but it would be nice if this was documented more explicitly.

### What was your diagnosis of the problem?

Just an option that's missing from the existing git installation documentation.

### What is your fix for the problem, implemented in this PR?

Added a short blurb to the documentation to make this option more discoverable for folks. 😄 

### Why did you choose this fix out of the possible options?

Not sure how you all choose what gems to use as examples. I just put down the one I needed to discover to use `:glob` for to install.

Open to any and all suggestions to clarify the copy or choose a different gem as an example.

Thanks!