### PR TITLE
Correct --requirements flag.

### DIFF
--- a/source/v1.16/bundle_viz.html.haml
+++ b/source/v1.16/bundle_viz.html.haml
@@ -15,7 +15,7 @@
       %p
         <code>--format or -F</code>: This is output format option. Supported format is png, jpg, svg, dot ...
       %p
-        <code>--requirements or -r</code>: Set to show the version of each required dependency.
+        <code>--requirements or -R</code>: Set to show the version of each required dependency.
       %p
         <code>--version or -v</code>: Set to show each gem version.
       %p


### PR DESCRIPTION
(see https://github.com/bundler/bundler/issues/6527)

---

### What was the end-user problem that led to this PR?

Documentation mismatched with the usage and online help in bunder viz

### What was your diagnosis of the problem?

My diagnosis was that `-r` is used for `--retry` and the correct `--requirements` flag is `-R` which is not reflected on the site.

### What is your fix for the problem, implemented in this PR?

Documentation modification to match the behaviour.

