### PR TITLE
Fixed the example of using Bundler in a single-file Ruby script

### DIFF
--- a/source/v1.16/guides/bundler_in_a_single_file_ruby_script.html.md
+++ b/source/v1.16/guides/bundler_in_a_single_file_ruby_script.html.md
@@ -17,7 +17,7 @@ To use Bundler in a single-file script, add `require 'bundler/inline' ` at the t
 	end
 
 	puts 'Gems installed and loaded!'
-	puts "The nap gem is at version #{Nap::VERSION}"
+	puts "The nap gem is at version #{REST::VERSION}"
 
 
 To run this script, including installing any missing gems, save the script into a file (for example, `bundler_inline_example.rb`) and then run the file with the command `ruby bundler_inline_example.rb`.


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The example of using Bundler in a single-file Ruby script https://bundler.io/v1.16/guides/bundler_in_a_single_file_ruby_script.html fails with 

```
>ruby bundler_inline_example.rb
Gems installed and loaded!
Traceback (most recent call last):
bundler_inline_example.rb:11:in `<main>': uninitialized constant Nap (NameError)
```

### What was your diagnosis of the problem?

`nap` gem has no `Nap` namespace currently. It has its `VERSION` constant in `REST` module.

### What is your fix for the problem, implemented in this PR?

Use the correct namespace. 

### Why did you choose this fix out of the possible options?

¯\\_(ツ)_/¯