### PR TITLE
Created "how to use Bundler with Docker guide"

### DIFF
--- a/source/v1.16/guides/bundler_docker_guide.html.md
+++ b/source/v1.16/guides/bundler_docker_guide.html.md
@@ -1,0 +1,31 @@
+---
+title: How to use Bundler with Docker
+---
+
+# How to use Bundler with Docker
+
+## Introduction 
+
+If you have tried to bundle an application in Docker with Bundler v1.16 or earlier, you may run into issues with explicitly setting `GEM_HOME`, `BUNDLE_BIN`, `BUNDLE_PATH`, and with adding the `BUNDLE_BIN` to the `PATH` in your Dockerfile similar to this:
+
+```
+ENV GEM_HOME="/usr/local/bundle"
+ENV BUNDLE_PATH="$GEM_HOME"
+ENV BUNDLE_BIN="$GEM_HOME/bin"
+ENV PATH="$BUNDLE_BIN:$PATH"
+```
+
+This is due to Docker treating Bundler binstubs as if they were RubyGems binstubs, which results in Bundler first creating RubyGems binstubs at `$BUNDLE_PATH/bin` and then overwriting those generic binstubs with application-locked Bundler binstubs (available in Bundler v1.16). 
+
+## How to fix the issue
+
+First, unset `BUNDLE_PATH` and `BUNDLE_BIN`, and change the `PATH` to use `$GEM_HOME/bin` in your Dockerfile:
+
+```
+ENV GEM_HOME="/usr/local/bundle"
+ENV PATH $GEM_HOME/bin:$GEM_HOME/gems/bin:$PATH
+```
+
+This will create the original generic RubyGems binstubs in `$GEM_HOME/bin`. (You will still be able to use gem commands like rake directly if there's only one version of the gem installed.) 
+
+If more than one version of a gem is installed, or if you want to use the application/Gemfile-specified version of a gem, run `bundle exec <gem name>`.


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

closes #386 

### What was the end-user problem that led to this PR?

The problem was...

Per #386:

> Based on bundler/bundler#6524, it looks like the Docker default images for Ruby have cleverly engineered a situation where only one bundle and one application can exist inside the docker container.

> For users who want to have more than one Gemfile, or simply install gems via RubyGems and use them as system gems, this situation is confusing, and has historically led to a lot of bug reports and even pull request against Bundler.

> Instead, we want to document how Bundler handles binstubs, document how the default Docker Ruby image handles binstubs, and then document how the user can configure Bundler within Docker to support whatever setup it is that they want.

...there

### What was your diagnosis of the problem?

My diagnosis was...

...to create a guide based on the fix @eanlain outlined [in this comment](https://github.com/bundler/bundler/pull/6524#issuecomment-406726953)

### What is your fix for the problem, implemented in this PR?

My fix...

...to create a guide based on the fix one of our users outlined [here](https://github.com/bundler/bundler/pull/6524#issuecomment-406726953)

cc @indirect 