### PR TITLE
Adding optional groups section to docs

### DIFF
--- a/source/v1.16/guides/groups.html.haml
+++ b/source/v1.16/guides/groups.html.haml
@@ -65,8 +65,16 @@ title: How to manage groups of gems
         require 'nokogiri'
       = link_to 'Learn More: Bundler.setup', './bundler_setup.html', class: 'btn btn-primary'
 
+
+    %h2#optional-groups
+      Optional groups and <code>--with</code>
+    .bullet
+      .description
+      Mark a group as optional using <code>group :name, optional: true do</code>, and then opt
+      into installing an optional group with <code>bundle install --with name</code>.
+
     %h2#grouping-your-dependencies
-      Grouping Your Dependencies
+      Grouping your dependencies
     .bullet
       .description
         You'll sometimes have groups of gems that only make sense in particular environments.


### PR DESCRIPTION
Closes #393 

As noted in #393, the only place in our documentation that contained information about optional groups was the v1.10 release notes. It was recommended that we add it to the "How to manage groups of gems" section, which this PR does.

Exact language that was added:

> Mark a group as optional using <code>group :name, optional: true do</code>, and then opt
  into installing an optional group with <code>bundle install --with name</code>.

Tested locally and the page renders correctly with the added section.
