### PR TITLE
Update git guide to standard hash syntax

### DIFF
--- a/source/v1.16/guides/git.html.haml
+++ b/source/v1.16/guides/git.html.haml
@@ -21,7 +21,7 @@ title: How to install gems from git repositories
         repository with a .gemspec at its root
       :code
         # lang: ruby
-        gem 'rack', :git => 'https://github.com/rack/rack'
+        gem 'rack', git: 'https://github.com/rack/rack'
     .bullet
       .description
         If there is no .gemspec at the root of
@@ -30,7 +30,7 @@ title: How to install gems from git repositories
         dependencies
       :code
         # lang: ruby
-        gem 'nokogiri', '1.7.0.1', :git => 'https://github.com/sparklemotion/nokogiri'
+        gem 'nokogiri', '1.7.0.1', git: 'https://github.com/sparklemotion/nokogiri'
     .bullet
       .description
         If the gem is located within a subdirectory of
@@ -38,7 +38,7 @@ title: How to install gems from git repositories
         to specify the location of its .gemspec
       :code
         # lang: ruby
-        gem 'cf-copilot', :git => 'https://github.com/cloudfoundry/copilot', :glob => 'sdk/ruby/*.gemspec'
+        gem 'cf-copilot', git: 'https://github.com/cloudfoundry/copilot', glob: 'sdk/ruby/*.gemspec'
     .bullet
       .description
         Specify that a git repository containing
@@ -56,9 +56,9 @@ title: How to install gems from git repositories
         From the previous example, you may specify a particular ref, branch or tag
       :code
         # lang: ruby
-        git 'https://github.com/rails/rails.git', :ref => '4aded' do
-        git 'https://github.com/rails/rails.git', :branch => '5-0-stable' do
-        git 'https://github.com/rails/rails.git', :tag => 'v5.0.0' do
+        git 'https://github.com/rails/rails.git', ref: '4aded' do
+        git 'https://github.com/rails/rails.git', branch: '5-0-stable' do
+        git 'https://github.com/rails/rails.git', tag: 'v5.0.0' do
     .bullet
       .description
         Specifying a ref, branch, or tag for a
@@ -66,53 +66,53 @@ title: How to install gems from git repositories
         exactly the same way
       :code
         # lang: ruby
-        gem 'nokogiri', :git => 'https://github.com/rack/rack.git', :ref => '0bd839d'
-        gem 'nokogiri', :git => 'https://github.com/rack/rack.git', :tag => '2.0.1'
-        gem 'nokogiri', :git => 'https://github.com/rack/rack.git', :branch => 'rack-1.5'
+        gem 'nokogiri', git: 'https://github.com/rack/rack.git', ref: '0bd839d'
+        gem 'nokogiri', git: 'https://github.com/rack/rack.git', tag: '2.0.1'
+        gem 'nokogiri', git: 'https://github.com/rack/rack.git', branch: 'rack-1.5'
     .bullet
       .description
         Bundler can use HTTP(S), SSH, or git
       :code
         # lang: ruby
-        gem 'rack', :git => 'https://github.com/rack/rack.git'
-        gem 'rack', :git => 'git@github.com:rack/rack.git'
-        gem 'rack', :git => 'git://github.com/rack/rack.git'
+        gem 'rack', git: 'https://github.com/rack/rack.git'
+        gem 'rack', git: 'git@github.com:rack/rack.git'
+        gem 'rack', git: 'git://github.com/rack/rack.git'
     .bullet
       .description
         Specify that the submodules from a git repository
         also should be expanded by bundler
       :code
         # lang: ruby
-        gem 'rugged', :git => 'git://github.com/libgit2/rugged.git', :submodules => true
+        gem 'rugged', git: 'git://github.com/libgit2/rugged.git', submodules: true
     .bullet
       .description
         If you are getting your gems from a public GitHub repository,
         you can use the shorthand
       :code
         # lang: ruby
-        gem 'rack', :github => 'rack/rack'
+        gem 'rack', github: 'rack/rack'
       .description
         If the repository name is the same as the GitHub account hosting it,
         you can omit it
       :code
         # lang: ruby
-        gem 'rails', :github => 'rails'
+        gem 'rails', github: 'rails'
       .description
         <b>NB:</b> This shorthand can only be used for public repos in Bundler version 1.x. Use HTTPS for read and write:
       :code
         # lang: ruby
-        gem 'rails', :git => 'https://github.com/rails/rails'
+        gem 'rails', git: 'https://github.com/rails/rails'
       .description
         All of the usual <code>:git</code> options apply, like <code>:branch</code> and <code>:ref</code>.
       :code
         # lang: ruby
-        gem 'rails', :github => 'rails', :ref => 'a9752dcfd15bcddfe7b6f7126f3a6e0ba5927c56'
+        gem 'rails', github: 'rails', ref: 'a9752dcfd15bcddfe7b6f7126f3a6e0ba5927c56'
       .description
         There are analogous shortcuts for Bitbucket (<code>:bitbucket</code>) and GitHub Gists (<code>:gist</code>).
       :code
         # lang: ruby
-        gem 'capistrano-sidekiq', :github => 'seuros/capistrano-sidekiq'
-        gem 'keystone', :bitbucket => 'musicone/keystone'
+        gem 'capistrano-sidekiq', github: 'seuros/capistrano-sidekiq'
+        gem 'keystone', bitbucket: 'musicone/keystone'
   %h2 Custom git sources
   .contents
     .bullet
@@ -128,7 +128,7 @@ title: How to install gems from git repositories
       :code
         # lang: ruby
         git_source(:stash){ |repo_name| "https://stash.corp.acme.pl/\#{repo_name}.git" }
-        gem 'rails', :stash => 'forks/rails'
+        gem 'rails', stash: 'forks/rails'
   %h2 Security
   .contents
     .bullet
@@ -158,7 +158,7 @@ title: How to install gems from git repositories
         and setup the git repo pointing to a branch:
       :code
         # lang: ruby
-        gem 'rack', :github => 'rack/rack', :branch => 'master'
+        gem 'rack', github: 'rack/rack', branch: 'master'
     .bullet
       .description
         %p


### PR DESCRIPTION
The git guide uses hash rocket style syntax. This PR updates to the standard hash syntax that pretty much everyone is using these days.