### PR TITLE
Clarify a sentence in rationale.html.haml

### DIFF
--- a/source/v1.16/rationale.html.haml
+++ b/source/v1.16/rationale.html.haml
@@ -37,7 +37,7 @@
       After declaring your first set of dependencies, you tell bundler to go get them:
 
     :code
-      $ bundle install    # 'bundle' is a shortcut for 'bundle install'
+      $ bundle install    # using 'bundle' on its own would do the same thing, as it's a shortcut for 'bundle install'
 
     %p
       Bundler will connect to <code>rubygems.org</code> (and any other sources that you declared),


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The code comment could previously suggest that `bundle` is a shortcut of `bundle install` **within the command** `bundle install`.

### What was your diagnosis of the problem?

It can be confusing to the user.

### What is your fix for the problem, implemented in this PR?

Clarify that `bundle` on its own is a shortcut of `bundle install`. Of course, please correct me if I'm wrong.
Also, let me know if the proposed code comment is too long for the snippet, and should be broken down into two lines or rephrased.
