### PR TITLE
Added the note about --binstubs.

### DIFF
--- a/source/v1.16/guides/sinatra.html.haml
+++ b/source/v1.16/guides/sinatra.html.haml
@@ -30,3 +30,5 @@ title: How to use Bundler with Sinatra
         Start your development server with rackup, and Sinatra will be loaded via Bundler.
       :code
         $ bundle exec rackup
+      .description
+        This will only work if when you ensure to use bundle install --binstubs to create the rackup command.


### PR DESCRIPTION
I tried following this guide and noticed the flag --binstubs needs to be executed prior to executing bundle exec rack up.

Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was...

### What was your diagnosis of the problem?

My diagnosis was...

### What is your fix for the problem, implemented in this PR?

My fix...

### Why did you choose this fix out of the possible options?

I chose this fix because...
