### PR TITLE
Rackup 'command not found' error for sinatra

### DIFF
--- a/source/v1.16/guides/sinatra.html.haml
+++ b/source/v1.16/guides/sinatra.html.haml
@@ -46,7 +46,3 @@ title: How to use Bundler with Sinatra
         $ bundle exec rackup
       .description
         The code should no longer produce the error and your development server will be up and running
-        
-        
-
-        

--- a/source/v1.16/guides/sinatra.html.haml
+++ b/source/v1.16/guides/sinatra.html.haml
@@ -30,3 +30,23 @@ title: How to use Bundler with Sinatra
         Start your development server with rackup, and Sinatra will be loaded via Bundler.
       :code
         $ bundle exec rackup
+      
+    .bullet  
+      .description
+        If you run the above command and receive a 'command not found' error
+        Ensure you have a bin folder in your projects root directory
+        Check to see that there is a file named 'rackup' within that folder
+        If you notice the file is not there run the following command:
+      :code
+        $ bundle install --binstubs
+      .description
+        This will install the executables needed for bundle exec
+        Attempt to rerun the following:
+      :code
+        $ bundle exec rackup
+      .description
+        The code should no longer produce the error and your development server will be up and running
+        
+        
+
+        


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

I tried following the guide for Sinatra apps and when I would run:
$ bundle exec rackup
I'd receive an error that the command did not exist.

### What was your diagnosis of the problem?

Because I had not run
$ bundle install --binstubs
previously in my app, I did not have a bin folder to exec gem commands like
$ bundle exec rackup
in this case

### What is your fix for the problem, implemented in this PR?

Fixed documentation to reflect that the bundle install must be run w/ --binstubs flag to ensure a folder of gem executables is created

### Why did you choose this fix out of the possible options?

I chose this fix because I was unable to get
$ bundle exec rackup
To work on my server but
$ ruby app/sinatra_app.rb would work just fine.

I also chose to fix this because I'm a new web developer with little experience looking to get my feet wet contributing to open source and had not found any decent solutions when googling the problem.