### PR TITLE
add note: Bundler 2.0 requires Ruby 2.3.0

### DIFF
--- a/source/compatibility.html.haml
+++ b/source/compatibility.html.haml
@@ -25,7 +25,6 @@ description: Ruby and RubyGems requirements needed for Bundler compatibility
     .description
       Bundler <b>2.0</b> requires a minimum Ruby version of <b>2.3.0</b>.
       Bundler <b>1.0</b> requires a minimum Ruby version of <b>1.8.7</b>.
-     
 
 %h2 Bundler compatibility with RubyGems
 

--- a/source/compatibility.html.haml
+++ b/source/compatibility.html.haml
@@ -23,8 +23,9 @@ description: Ruby and RubyGems requirements needed for Bundler compatibility
 
   .bullet
     .description
+      Bundler <b>2.0</b> requires a minimum Ruby version of <b>2.3.0</b>.
       Bundler <b>1.0</b> requires a minimum Ruby version of <b>1.8.7</b>.
-
+     
 
 %h2 Bundler compatibility with RubyGems
 


### PR DESCRIPTION
https://bundler.io/compatibility.html should have a note that Bundler 2.0 requires Ruby 2.3.0
> REQUIRED RUBY-VERSION:
> &gt;= 2.3.0
> REQUIRED RUBYGEMS VERSION:
> &gt;= 3.0.0

source: https://rubygems.org/gems/bundler/versions/2.0.0


### What was the end-user problem that led to this PR?

`gem install bundler # on older ruby version`
ERROR:  Error installing bundler:
	bundler requires Ruby version >= 2.3.0.

### What was your diagnosis of the problem?

New Bundler version requires Ruby 2.3.0
The problem was incomplete documentation.

### What is your fix for the problem, implemented in this PR?

My fix was `gem install bundler --version '< 2'`
