### PR TITLE
Change RubyGems requirement to v2.5.0 from v3.0.0 at minimum

### DIFF
--- a/source/v2.0/guides/bundler_2_upgrade.html.md
+++ b/source/v2.0/guides/bundler_2_upgrade.html.md
@@ -6,10 +6,10 @@ title: How to Upgrade to Bundler 2
 
 So! You’ve heard that [Bundler 2 was released](https://bundler.io/blog/2019/01/03/announcing-bundler-2.html)! If you want to try out Bundler 2 for yourself, this guide will help you do that.
 
-Bundler 2 is almost entirely the same as the previous version, 1.17. The big change is that Bundler now requires at least Ruby 2.3.0 and RubyGems 3.0.0.
+Bundler 2 is almost entirely the same as the previous version, 1.17. The big change is that Bundler now requires at least Ruby 2.3.0 and RubyGems 2.5.0.
 
 ### Prerequisites
-Before you upgrade to Bundler 2, make sure you have the right Ruby and RubyGems. You need to be using Ruby 2.3.0 or higher, and you need to have RubyGems 3.0.0 or higher.
+Before you upgrade to Bundler 2, make sure you have the right Ruby and RubyGems. You need to be using Ruby 2.3.0 or higher, and you need to have RubyGems 2.5.0 or higher.
 
 You can check your Ruby version by running `ruby --version`, and you can check your RubyGems version by running `gem --version`. If you need to upgrade Ruby, use your ruby version manager’s instructions. If you need to upgrade RubyGems, run `gem update --system`.
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?
The problem was that "How to upgrade to Bundler 2" document made users to misunderstand RubyGems requirement at minimum. 

Indeed, in bundler v2.0.0, the requirement was v3.0.0 at minimum.
However, since bundler v2.0.1, the requirement was relaxed to v2.5.0 from v3.0.0.

ref : https://bundler.io/blog/2019/01/04/an-update-on-the-bundler-2-release.html

### What was your diagnosis of the problem?
None

### What is your fix for the problem, implemented in this PR?

My fix is changing RubyGems requirement to v2.5.0 from v3.0.0 in "How to Upgrade to Bundler 2" document.

### Why did you choose this fix out of the possible options?
None