### PR TITLE
Make Heroku upgrade info match blog post

### DIFF
--- a/source/v2.0/guides/bundler_2_upgrade.html.md
+++ b/source/v2.0/guides/bundler_2_upgrade.html.md
@@ -98,7 +98,9 @@ Bundler 2 includes these changes:
 * Print Bundler errors to STDERR instead of STDOUT
 * The `github:` shortcut in the `Gemfile` will use `https` instead of `http`
 
-### Will Heroku have bundler 2?
-The Heroku team has said they plan to upgrade the official Ruby buildpack to Bundler 2, but it will take some time. They have a zillion users, so that totally makes sense.
+### Can I use Bundler 2 on Heroku?
+Yes you can! The Heroku team has said they plan to upgrade the official Ruby buildpack to Bundler 2, but it will take some time. They have a zillion users, so that totally makes sense.
 
-In the meantime, you can use our [buildpack](https://github.com/bundler/heroku-buildpack-bundler2), which is exactly the same but with Bundler 2, by running:
+In the meantime, you can use our [buildpack](https://github.com/bundler/heroku-buildpack-bundler2), which is exactly the same as Heroku’s but with Bundler 2.
+
+Note: Support for the Bundler 2 buildpack is limited. You are welcome to report issues at the [bundler/heroku-buildpack-bundler2](https://github.com/bundler/heroku-buildpack-bundler2) repository, but we can’t guarantee solutions.


### PR DESCRIPTION
The guide on the website has a hanging "by running:" followed by nothing which is confusing. Someone already noticed and fixed this in #431 but those didn't get translated to the upgrade guide on the website. I've copied the entire question wording verbatim for consistency, but if someone thinks it'd be better not to include the note about support, question change, etc. I can update this. At the very least, the "by running" should be removed so the sentence makes sense.

Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was...

### What was your diagnosis of the problem?

My diagnosis was...

### What is your fix for the problem, implemented in this PR?

My fix...

### Why did you choose this fix out of the possible options?

I chose this fix because...
