### PR TITLE
Fix 'BUNDLED_WITH' -> 'BUNDLED WITH'

### DIFF
--- a/source/v2.0/guides/bundler_2_upgrade.html.md
+++ b/source/v2.0/guides/bundler_2_upgrade.html.md
@@ -69,7 +69,7 @@ Your existing applications will continue to use Bundler 1. Bundler will never ch
 We recommend committing your Gemfile.lock before you upgrade. That way, if something goes wrong or doesn’t work, you can always revert to the previous lockfile and go back to using Bundler 1.
 
 ### Using Bundler 2 with new applications
-When you create a new application, using `bundle init`, `rails new`, or something like that, your application will use the newest version of Bundler that is currently installed. If you have Bundler 2 installed, your application will be locked to Bundler 2. You can verify this by reading the lockfile, looking for the section named `BUNDLED_WITH`.
+When you create a new application, using `bundle init`, `rails new`, or something like that, your application will use the newest version of Bundler that is currently installed. If you have Bundler 2 installed, your application will be locked to Bundler 2. You can verify this by reading the lockfile, looking for the section named `BUNDLED WITH`.
 
 ## FAQ
 


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that the section name `BUNDLED_WITH` isn't actually a section in a Bundler lockfile.

### What was your diagnosis of the problem?

My diagnosis was that this should have said `BUNDLED WITH`.

### What is your fix for the problem, implemented in this PR?

My fix was to change `BUNDLED_WITH` to `BUNDLED WITH`.

### Why did you choose this fix out of the possible options?

I chose this fix because it's clearly what was intended.
