### PR TITLE
Heroku now supports Bundler 2

### DIFF
--- a/source/v2.0/guides/bundler_2_upgrade.html.md
+++ b/source/v2.0/guides/bundler_2_upgrade.html.md
@@ -99,8 +99,4 @@ Bundler 2 includes these changes:
 * The `github:` shortcut in the `Gemfile` will use `https` instead of `http`
 
 ### Can I use Bundler 2 on Heroku?
-Yes you can! The Heroku team has said they plan to upgrade the official Ruby buildpack to Bundler 2, but it will take some time. They have a zillion users, so that totally makes sense.
-
-In the meantime, you can use our [buildpack](https://github.com/bundler/heroku-buildpack-bundler2), which is exactly the same as Heroku’s but with Bundler 2.
-
-Note: Support for the Bundler 2 buildpack is limited. You are welcome to report issues at the [bundler/heroku-buildpack-bundler2](https://github.com/bundler/heroku-buildpack-bundler2) repository, but we can’t guarantee solutions.
+Yes you can! The Heroku team has upgraded the official Ruby buildpack to [support Bundler 2](https://devcenter.heroku.com/articles/ruby-support#libraries). See [Heroku's article on Bundler version](https://devcenter.heroku.com/articles/bundler-version) for more details.


### PR DESCRIPTION
Heroku now supports Bundler 2 with the official Ruby buildpack, so the documentation can now reflect this.