### PR TITLE
Clarify that Heroku has support for Bundler 2 now

### DIFF
--- a/source/v2.0/guides/bundler_2_upgrade.html.md
+++ b/source/v2.0/guides/bundler_2_upgrade.html.md
@@ -99,8 +99,4 @@ Bundler 2 includes these changes:
 * The `github:` shortcut in the `Gemfile` will use `https` instead of `http`
 
 ### Can I use Bundler 2 on Heroku?
-Yes you can! The Heroku team has said they plan to upgrade the official Ruby buildpack to Bundler 2, but it will take some time. They have a zillion users, so that totally makes sense.
-
-In the meantime, you can use our [buildpack](https://github.com/bundler/heroku-buildpack-bundler2), which is exactly the same as Heroku’s but with Bundler 2.
-
-Note: Support for the Bundler 2 buildpack is limited. You are welcome to report issues at the [bundler/heroku-buildpack-bundler2](https://github.com/bundler/heroku-buildpack-bundler2) repository, but we can’t guarantee solutions.
+Yes you can! The Heroku team has upgraded the official Ruby buildpack to Bundler 2. Their [documentation for different Bundler versions](https://devcenter.heroku.com/articles/bundler-version) include a list of [common upgrade issues](https://devcenter.heroku.com/articles/bundler-version#bundler-2-0-1).


### PR DESCRIPTION
Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

The problem was that the guide on https://bundler.io/guides/bundler_2_upgrade.html contains now-outdated information in regards to Herokus support for Bundler 2.

I recently upgraded one of our apps running on Heroku to Bundler 2 and was able to get it working with just Herokus official Ruby buildpack.

My fix removes the section that describes the Bundler-supported buildpack and replace it with references to Herokus official documentation.