### PR TITLE
Fix blog command syntax highlighting

### DIFF
--- a/source/blog/2019-05-14-solutions-for-cant-find-gem-bundler-with-executable-bundle.html.markdown
+++ b/source/blog/2019-05-14-solutions-for-cant-find-gem-bundler-with-executable-bundle.html.markdown
@@ -6,7 +6,7 @@ author: Colby Swandale
 category: release
 ---
 
-TL;DR: `run gem update --system`.
+TL;DR: run `gem update --system`.
 
 ## What is this bug?
 


### PR DESCRIPTION
Readers might incorrectly copy the command and try to execute `run`.