### PR TITLE
Docs(gems-from-git page): Fix incorrect URLs for nokogiri

### DIFF
--- a/source/v2.0/guides/git.html.haml
+++ b/source/v2.0/guides/git.html.haml
@@ -66,9 +66,9 @@ title: How to install gems from git repositories
         exactly the same way
       :code
         # lang: ruby
-        gem 'nokogiri', git: 'https://github.com/rack/rack.git', ref: '0bd839d'
-        gem 'nokogiri', git: 'https://github.com/rack/rack.git', tag: '2.0.1'
-        gem 'nokogiri', git: 'https://github.com/rack/rack.git', branch: 'rack-1.5'
+        gem 'nokogiri', git: 'https://github.com/sparklemotion/nokogiri.git', ref: '0bd839d'
+        gem 'nokogiri', git: 'https://github.com/sparklemotion/nokogiri.git', tag: '2.0.1'
+        gem 'nokogiri', git: 'https://github.com/sparklemotion/nokogiri.git', branch: 'rack-1.5'
     .bullet
       .description
         Bundler can use HTTP(S), SSH, or git


### PR DESCRIPTION
### What was the end-user problem that led to this PR?

The problem was that this example was pointing nokogiri to rack, pretty sure that's not right.

### What is your fix for the problem, implemented in this PR?

The URLs have been updated.  

### Why did you choose this fix out of the possible options?

Seemed most logical
